### PR TITLE
Add asynchronous runner support for concurrent runs

### DIFF
--- a/ai_testing_tool/__init__.py
+++ b/ai_testing_tool/__init__.py
@@ -1,5 +1,5 @@
 """Core package for the AI testing tool."""
 
-from .runner import RunResult, run_tasks, main
+from .runner import RunResult, main, run_tasks, run_tasks_async
 
-__all__ = ["RunResult", "run_tasks", "main"]
+__all__ = ["RunResult", "run_tasks", "run_tasks_async", "main"]


### PR DESCRIPTION
## Summary
- add an asynchronous wrapper around the task runner that executes work inside a shared thread pool so multiple runs can progress concurrently
- expose the new asynchronous runner via the FastAPI endpoint and package exports while keeping the synchronous API for CLI compatibility

## Testing
- pytest
- pre-commit run --files ai_testing_tool/runner.py ai_testing_tool/api.py ai_testing_tool/__init__.py *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68d08e67821c832a812a00b66881f4f5