### PR TITLE
Add Redis-backed queue for asynchronous task execution

### DIFF
--- a/ai_testing_tool/queue_runner.py
+++ b/ai_testing_tool/queue_runner.py
@@ -1,0 +1,88 @@
+"""Background worker that consumes the Redis task queue."""
+
+from __future__ import annotations
+
+import json
+import signal
+from typing import Any, Dict, Optional
+
+from redis import RedisError
+
+from runner import _run_tasks
+from task_queue import (
+    create_redis_client,
+    dump_status,
+    queue_key,
+    status_key,
+)
+
+
+def _update_status(redis_client: Any, task_id: str, payload: Dict[str, Any]) -> None:
+    """Persist ``payload`` as the status for ``task_id``."""
+
+    redis_client.set(status_key(task_id), dump_status(payload))
+
+
+def _process_task(redis_client: Any, raw_task: str) -> None:
+    """Execute a single queued task represented by ``raw_task``."""
+
+    task: Dict[str, Any] = json.loads(raw_task)
+    task_id = task["task_id"]
+    _update_status(redis_client, task_id, {"status": "running"})
+
+    try:
+        result = _run_tasks(
+            task["prompt"],
+            task["tasks"],
+            task["server"],
+            task["platform"],
+            task["reports_folder"],
+            task["debug"],
+        )
+    except Exception as exc:  # pragma: no cover - background safety net
+        _update_status(
+            redis_client,
+            task_id,
+            {"status": "failed", "error": str(exc)},
+        )
+        return
+
+    _update_status(
+        redis_client,
+        task_id,
+        {
+            "status": "completed",
+            "summary": result.summary,
+            "summary_path": result.summary_path,
+        },
+    )
+
+
+def main() -> None:
+    """Run the blocking loop that processes queued tasks."""
+
+    redis_client = create_redis_client()
+
+    def _handle_shutdown(signum: int, _frame: Optional[Any]) -> None:
+        raise KeyboardInterrupt
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, _handle_shutdown)
+
+    try:
+        while True:
+            item = redis_client.blpop(queue_key(), timeout=5)
+            if not item:
+                continue
+            _, raw_task = item
+            _process_task(redis_client, raw_task)
+    except KeyboardInterrupt:
+        print("Shutting down queue runner")
+    except RedisError as exc:  # pragma: no cover - operational errors
+        print(f"[ERROR] Redis interaction failed: {exc}")
+    finally:
+        redis_client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_testing_tool/task_queue.py
+++ b/ai_testing_tool/task_queue.py
@@ -1,0 +1,58 @@
+"""Utilities for interacting with the Redis-backed task queue."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
+
+
+DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+_QUEUE_KEY_ENV = "AITASK_QUEUE_KEY"
+_STATUS_PREFIX_ENV = "AITASK_STATUS_PREFIX"
+
+
+def _redis_url() -> str:
+    """Return the Redis connection URL from the environment."""
+
+    return os.getenv("REDIS_URL", DEFAULT_REDIS_URL)
+
+
+def queue_key() -> str:
+    """Return the Redis list key used for pending tasks."""
+
+    return os.getenv(_QUEUE_KEY_ENV, "ai_testing_tool:queue")
+
+
+def status_key(task_id: str) -> str:
+    """Return the Redis key storing status for ``task_id``."""
+
+    prefix = os.getenv(_STATUS_PREFIX_ENV, "ai_testing_tool:status:")
+    return f"{prefix}{task_id}"
+
+
+def create_async_redis_client() -> AsyncRedis:
+    """Create an asynchronous Redis client instance."""
+
+    return AsyncRedis.from_url(_redis_url(), decode_responses=True)
+
+
+def create_redis_client() -> Redis:
+    """Create a synchronous Redis client instance."""
+
+    return Redis.from_url(_redis_url(), decode_responses=True)
+
+
+def dump_status(payload: Dict[str, Any]) -> str:
+    """Serialise a status payload into a JSON string."""
+
+    return json.dumps(payload)
+
+
+def load_status(raw: str) -> Dict[str, Any]:
+    """Parse a stored JSON status payload from Redis."""
+
+    return json.loads(raw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 selenium
 fastapi
 uvicorn
+redis


### PR DESCRIPTION
## Summary
- queue new /run requests in Redis and expose task status/result endpoints
- add shared Redis helpers and a queue runner that executes tasks via the existing runner implementation
- include the redis client dependency required by the new queue integration

## Testing
- pytest
- pre-commit run --files ai_testing_tool/api.py ai_testing_tool/queue_runner.py ai_testing_tool/task_queue.py requirements.txt *(fails: command not found; pip install pre-commit blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d0964bbd78832aaf186f89d29b1d50