### PR TITLE
Add authentication, authorization, and result tabs

### DIFF
--- a/ai_testing_tool/api.py
+++ b/ai_testing_tool/api.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import datetime as dt
+import hashlib
 import json
 import os
+import re
+import secrets
+import sqlite3
 import uuid
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, EmailStr, Field
 from redis.asyncio import Redis
 
 from task_queue import (
@@ -73,6 +81,14 @@ class TaskStatus(str, Enum):
     failed = "failed"
 
 
+class StepInfo(BaseModel):
+    """Metadata for an execution step screenshot."""
+
+    index: int
+    filename: str
+    image_url: str
+
+
 class TaskStatusResponse(BaseModel):
     """Status payload returned when querying for a task."""
 
@@ -81,6 +97,8 @@ class TaskStatusResponse(BaseModel):
     summary: Optional[List[Dict[str, Any]]] = None
     summary_path: Optional[str] = None
     error: Optional[str] = None
+    owner_id: Optional[str] = None
+    steps: Optional[List[StepInfo]] = None
 
 
 class TaskCollectionResponse(BaseModel):
@@ -98,7 +116,9 @@ class TaskCollectionResponse(BaseModel):
 app = FastAPI(
     title="AI Testing Tool API",
     version="1.0.0",
-    description="Run cross-platform automation tasks (Android/iOS/Web) via an AI agent.",
+    description=(
+        "Run cross-platform automation tasks (Android/iOS/Web) via an AI agent."
+    ),
 )
 
 # CORS (adjust origins as needed)
@@ -108,6 +128,12 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+
+app.mount(
+    "/reports",
+    StaticFiles(directory=_REPORTS_ROOT, html=False, check_dir=False),
+    name="reports",
 )
 
 
@@ -132,21 +158,32 @@ def _redis_client() -> Redis:
 
     redis: Optional[Redis] = getattr(app.state, "redis", None)
     if redis is None:
-        raise HTTPException(status_code=503, detail="Redis client is unavailable")
+        raise HTTPException(
+            status_code=503,
+            detail="Redis client is unavailable",
+        )
     return redis
 
 
 @app.on_event("startup")
 def _ensure_reports_folder() -> None:
-    # Create the default reports folder up front so writes won't fail.
-    default_reports = "./reports"
+    """Create the reports directory eagerly to avoid runtime errors."""
+
     try:
-        os.makedirs(default_reports, exist_ok=True)
-    except Exception as exc:  # pragma: no cover
-        # Not fatal; individual runs also try to create their own paths.
-        print(
-            f"[WARN] Failed to create default reports folder '{default_reports}': {exc}"
+        _REPORTS_ROOT.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:  # pragma: no cover - filesystem issue
+        warning = "[WARN] Failed to create reports folder '%s': %s" % (
+            _REPORTS_ROOT,
+            exc,
         )
+        print(warning)
+
+
+@app.on_event("startup")
+def _setup_database() -> None:
+    """Initialise the SQLite database on application startup."""
+
+    _init_database()
 
 
 @app.get("/", summary="Health check")
@@ -155,37 +192,98 @@ def read_root() -> Dict[str, str]:
     return {"status": "ok"}
 
 
+@app.post(
+    "/auth/signup",
+    response_model=AuthResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register a new user",
+)
+def signup(payload: SignUpRequest) -> AuthResponse:
+    """Create a new user account and return an access token."""
+
+    user = _create_user(payload.email, payload.password)
+    token = _store_token(user)
+    return AuthResponse(access_token=token, user=_user_payload(user))
+
+
+@app.post(
+    "/auth/login",
+    response_model=AuthResponse,
+    summary="Authenticate and receive an access token",
+)
+def login(payload: LoginRequest) -> AuthResponse:
+    """Authenticate an existing user and issue a bearer token."""
+
+    user = _authenticate_user(payload.email, payload.password)
+    token = _store_token(user)
+    return AuthResponse(access_token=token, user=_user_payload(user))
+
+
+@app.post(
+    "/auth/logout",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revoke the current access token",
+)
+def logout(authorization: str = Header(...)) -> None:
+    """Invalidate the token provided in the ``Authorization`` header."""
+
+    token = _parse_bearer_token(authorization)
+    _delete_token(token)
+
+
+@app.get(
+    "/auth/me",
+    response_model=UserResponse,
+    summary="Retrieve the authenticated user's profile",
+)
+async def read_profile(
+    current_user: User = Depends(get_current_user),
+) -> UserResponse:
+    """Return the basic profile information for the active user."""
+
+    return _user_payload(current_user)
+
+
 @app.post("/run", response_model=RunResponse, summary="Run automation tasks")
-async def run_automation(request: RunRequest) -> RunResponse:
+async def run_automation(
+    request: RunRequest, current_user: User = Depends(get_current_user)
+) -> RunResponse:
     """Enqueue automation tasks to be executed by the background runner."""
 
     redis = _redis_client()
     task_id = uuid.uuid4().hex
     payload = request.dict()
     payload["task_id"] = task_id
+    payload["user_id"] = current_user.id
 
     try:
         await redis.set(
             status_key(task_id),
-            dump_status({"status": TaskStatus.pending.value}),
+            dump_status(
+                {
+                    "status": TaskStatus.pending.value,
+                    "user_id": current_user.id,
+                }
+            ),
         )
         await redis.rpush(queue_key(), json.dumps(payload))
-    except Exception as exc:  # pragma: no cover - operational failure propagation
-        raise HTTPException(
-            status_code=503,
-            detail=f"Failed to enqueue task: {exc}",
-        ) from exc
+    except Exception as exc:  # pragma: no cover - enqueue failure
+        message = f"Failed to enqueue task: {exc}"
+        raise HTTPException(status_code=503, detail=message) from exc
 
     return RunResponse(task_id=task_id)
 
 
-async def _fetch_task_status(task_id: str) -> TaskStatusResponse:
+async def _fetch_task_status(
+    task_id: str,
+    current_user: User,
+) -> TaskStatusResponse:
     """Load the task status payload from Redis and validate it."""
 
     redis = _redis_client()
     try:
         raw_status = await redis.get(status_key(task_id))
-    except Exception as exc:  # pragma: no cover - operational failure propagation
+    except Exception as exc:  # pragma: no cover - operational failure
         raise HTTPException(
             status_code=503, detail=f"Failed to read task status: {exc}"
         ) from exc
@@ -194,10 +292,20 @@ async def _fetch_task_status(task_id: str) -> TaskStatusResponse:
         raise HTTPException(status_code=404, detail="Unknown task id")
 
     data = load_status(raw_status)
-    return TaskStatusResponse(task_id=task_id, **data)
+    owner_id = data.pop("user_id", None)
+    if owner_id is None and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Task is not accessible")
+    if not current_user.is_admin and owner_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Task is not accessible")
+
+    return TaskStatusResponse(
+        task_id=task_id,
+        owner_id=owner_id,
+        **data,
+    )
 
 
-async def _collect_tasks_by_status() -> TaskCollectionResponse:
+async def _collect_tasks_by_status(user: User) -> TaskCollectionResponse:
     """Return all known task identifiers grouped by their status."""
 
     redis = _redis_client()
@@ -215,18 +323,22 @@ async def _collect_tasks_by_status() -> TaskCollectionResponse:
             if raw_status is None:
                 continue
             data = load_status(raw_status)
-            status = data.get("status")
+            owner_id = data.get("user_id")
+            if not user.is_admin and owner_id != user.id:
+                continue
+
+            status_value = data.get("status")
             task_id = key.removeprefix(prefix)
 
-            if status == TaskStatus.completed.value:
+            if status_value == TaskStatus.completed.value:
                 grouped["completed"].append(task_id)
-            elif status == TaskStatus.pending.value:
+            elif status_value == TaskStatus.pending.value:
                 grouped["pending"].append(task_id)
-            elif status == TaskStatus.running.value:
+            elif status_value == TaskStatus.running.value:
                 grouped["running"].append(task_id)
-            elif status == TaskStatus.failed.value:
+            elif status_value == TaskStatus.failed.value:
                 grouped["error"].append(task_id)
-    except Exception as exc:  # pragma: no cover - operational failure propagation
+    except Exception as exc:  # pragma: no cover - operational failure
         raise HTTPException(
             status_code=503, detail=f"Failed to list tasks: {exc}"
         ) from exc
@@ -234,15 +346,63 @@ async def _collect_tasks_by_status() -> TaskCollectionResponse:
     return TaskCollectionResponse(**grouped)
 
 
+def _step_candidates(directory: Path) -> Iterable[Path]:
+    """Yield potential screenshot files from ``directory``."""
+
+    for extension in ("png", "jpg", "jpeg"):
+        yield from directory.glob(f"step_*.{extension}")
+
+
+def _build_step_images(summary_path: Optional[str]) -> List[StepInfo]:
+    """Return ordered :class:`StepInfo` entries for ``summary_path``."""
+
+    if not summary_path:
+        return []
+
+    try:
+        summary_file = Path(summary_path).resolve()
+    except (OSError, RuntimeError):  # pragma: no cover - invalid path
+        return []
+
+    directory = summary_file.parent
+    if not directory.exists():
+        return []
+
+    chosen: Dict[int, Path] = {}
+    for candidate in _step_candidates(directory):
+        match = re.search(r"step_(\d+)", candidate.name)
+        if not match:
+            continue
+        index = int(match.group(1))
+        if index in chosen:
+            continue
+        try:
+            relative = candidate.resolve().relative_to(_REPORTS_ROOT)
+        except ValueError:
+            continue
+        chosen[index] = relative
+
+    step_infos: List[StepInfo] = []
+    for index in sorted(chosen):
+        relative = chosen[index]
+        image_url = f"/reports/{relative.as_posix()}"
+        step_infos.append(
+            StepInfo(index=index, filename=relative.name, image_url=image_url)
+        )
+    return step_infos
+
+
 @app.get(
     "/tasks/{task_id}",
     response_model=TaskStatusResponse,
     summary="Retrieve current task status",
 )
-async def get_task_status(task_id: str) -> TaskStatusResponse:
+async def get_task_status(
+    task_id: str, current_user: User = Depends(get_current_user)
+) -> TaskStatusResponse:
     """Return the latest status information for ``task_id``."""
 
-    return await _fetch_task_status(task_id)
+    return await _fetch_task_status(task_id, current_user)
 
 
 @app.get(
@@ -250,10 +410,12 @@ async def get_task_status(task_id: str) -> TaskStatusResponse:
     response_model=TaskCollectionResponse,
     summary="List all queued tasks grouped by status",
 )
-async def list_tasks() -> TaskCollectionResponse:
+async def list_tasks(
+    current_user: User = Depends(get_current_user),
+) -> TaskCollectionResponse:
     """Return the collection of task identifiers grouped by their status."""
 
-    return await _collect_tasks_by_status()
+    return await _collect_tasks_by_status(current_user)
 
 
 @app.get(
@@ -261,13 +423,46 @@ async def list_tasks() -> TaskCollectionResponse:
     response_model=TaskStatusResponse,
     summary="Retrieve final task result",
 )
-async def get_task_result(task_id: str) -> TaskStatusResponse:
+async def get_task_result(
+    task_id: str, current_user: User = Depends(get_current_user)
+) -> TaskStatusResponse:
     """Return the final result once the task has completed."""
 
-    status = await _fetch_task_status(task_id)
+    status = await _fetch_task_status(task_id, current_user)
     if status.status in {TaskStatus.pending, TaskStatus.running}:
         raise HTTPException(status_code=202, detail="Task is still in progress")
-    return status
+    steps = _build_step_images(status.summary_path)
+    return status.copy(update={"steps": steps})
+
+
+@app.delete(
+    "/tasks/{task_id}",
+    status_code=204,
+    summary="Delete a task and its status",
+)
+async def delete_task(
+    task_id: str, current_user: User = Depends(get_current_user)
+) -> None:
+    """Remove a queued or completed task if the user is authorised."""
+
+    await _fetch_task_status(task_id, current_user)
+    redis = _redis_client()
+
+    try:
+        queue_entries = await redis.lrange(queue_key(), 0, -1)
+        for raw_entry in queue_entries:
+            try:
+                item = json.loads(raw_entry)
+            except json.JSONDecodeError:  # pragma: no cover - malformed payload
+                continue
+            if item.get("task_id") == task_id:
+                await redis.lrem(queue_key(), 0, raw_entry)
+                break
+        await redis.delete(status_key(task_id))
+    except Exception as exc:  # pragma: no cover - operational failure
+        raise HTTPException(
+            status_code=503, detail=f"Failed to delete task: {exc}"
+        ) from exc
 
 
 # -----------------------------
@@ -277,14 +472,289 @@ if __name__ == "__main__":
     # Environment-configurable server settings
     host = os.getenv("APP_HOST", "0.0.0.0")
     port = int(os.getenv("APP_PORT", "8090"))
-    reload_opt = os.getenv("APP_RELOAD", "true").lower() in {"1", "true", "yes"}
+    reload_opt = os.getenv("APP_RELOAD", "true").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
     import uvicorn
 
     uvicorn.run(
-        "api:app",  # if your file name is app.py; otherwise use "<filename_without_py>:app"
+        "api:app",
         host=host,
         port=port,
         reload=reload_opt,
         log_level=os.getenv("APP_LOG_LEVEL", "info"),
     )
+# -----------------------------
+# Database & Auth helpers
+# -----------------------------
+
+
+@dataclass
+class User:
+    """Authenticated API consumer."""
+
+    id: str
+    email: str
+    role: str
+
+    @property
+    def is_admin(self) -> bool:
+        """Return ``True`` when the user has administrative permissions."""
+
+        return self.role.lower() == "admin"
+
+
+class UserResponse(BaseModel):
+    """Public user payload returned to clients."""
+
+    id: str
+    email: EmailStr
+    role: str
+
+
+class AuthResponse(BaseModel):
+    """Authentication payload containing a bearer token."""
+
+    access_token: str
+    token_type: str = "bearer"
+    user: UserResponse
+
+
+class SignUpRequest(BaseModel):
+    """Payload for registering a new user."""
+
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+
+
+class LoginRequest(BaseModel):
+    """Payload for authenticating an existing user."""
+
+    email: EmailStr
+    password: str
+
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_DB_PATH = Path(os.getenv("AITOOL_DB_PATH", str(_PACKAGE_ROOT / "auth.db")))
+_REPORTS_ROOT = Path(
+    os.getenv("REPORTS_ROOT", str(_PACKAGE_ROOT / "reports"))
+).resolve()
+
+
+def _init_database() -> None:
+    """Create the SQLite database used for authentication."""
+
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(_DB_PATH)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                email TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                salt TEXT NOT NULL,
+                role TEXT NOT NULL DEFAULT 'user'
+            );
+
+            CREATE TABLE IF NOT EXISTS auth_tokens (
+                token TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _hash_password(password: str, salt: str) -> str:
+    """Derive a secure hash for ``password`` using ``salt``."""
+
+    digest = hashlib.pbkdf2_hmac(
+        "sha256", password.encode("utf-8"), salt.encode("utf-8"), 150_000
+    )
+    return digest.hex()
+
+
+def _create_user(email: str, password: str) -> User:
+    """Persist a new user in the database."""
+
+    user_id = uuid.uuid4().hex
+    salt = secrets.token_hex(16)
+    password_hash = _hash_password(password, salt)
+
+    conn = sqlite3.connect(_DB_PATH)
+    try:
+        conn.execute(
+            (
+                "INSERT INTO users (id, email, password_hash, salt) "
+                "VALUES (?, ?, ?, ?)"
+            ),
+            (user_id, email.lower(), password_hash, salt),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError as exc:  # pragma: no cover - uniqueness guard
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        ) from exc
+    finally:
+        conn.close()
+
+    return User(id=user_id, email=email.lower(), role="user")
+
+
+def _get_user_by_email(email: str) -> Optional[sqlite3.Row]:
+    """Return the raw database row for ``email`` if present."""
+
+    conn = sqlite3.connect(_DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        query = " ".join(
+            [
+                "SELECT id, email, role, password_hash, salt",
+                "FROM users WHERE email=?",
+            ]
+        )
+        cursor = conn.execute(query, (email.lower(),))
+        return cursor.fetchone()
+    finally:
+        conn.close()
+
+
+def _authenticate_user(email: str, password: str) -> User:
+    """Validate credentials and return the authenticated user."""
+
+    row = _get_user_by_email(email)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+
+    expected = _hash_password(password, row["salt"])
+    if secrets.compare_digest(expected, row["password_hash"]) is False:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+
+    return User(id=row["id"], email=row["email"], role=row["role"])
+
+
+def _store_token(user: User) -> str:
+    """Create and persist a bearer token for ``user``."""
+
+    token = secrets.token_urlsafe(32)
+    now = dt.datetime.utcnow().isoformat()
+    conn = sqlite3.connect(_DB_PATH)
+    try:
+        conn.execute(
+            (
+                "INSERT INTO auth_tokens (token, user_id, created_at) "
+                "VALUES (?, ?, ?)"
+            ),
+            (token, user.id, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return token
+
+
+def _row_to_user(row: sqlite3.Row) -> User:
+    """Convert a database row into a :class:`User`."""
+
+    return User(id=row["id"], email=row["email"], role=row["role"])
+
+
+def _token_lookup(token: str) -> Optional[User]:
+    """Return the :class:`User` associated with ``token`` if valid."""
+
+    conn = sqlite3.connect(_DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(
+            """
+            SELECT users.id, users.email, users.role
+            FROM auth_tokens
+            JOIN users ON users.id = auth_tokens.user_id
+            WHERE auth_tokens.token = ?
+            """,
+            (token,),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        return None
+    return _row_to_user(row)
+
+
+def _delete_token(token: str) -> None:
+    """Remove ``token`` from the database."""
+
+    conn = sqlite3.connect(_DB_PATH)
+    try:
+        conn.execute("DELETE FROM auth_tokens WHERE token = ?", (token,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _user_payload(user: User) -> UserResponse:
+    """Return a serialisable representation of ``user``."""
+
+    return UserResponse(id=user.id, email=user.email, role=user.role)
+
+
+def _parse_bearer_token(authorization: str) -> str:
+    """Extract the bearer token from the ``Authorization`` header."""
+
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
+
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header",
+        )
+    return parts[1]
+
+
+async def get_current_user(authorization: str = Header(...)) -> User:
+    """FastAPI dependency that resolves the authenticated user."""
+
+    token = _parse_bearer_token(authorization)
+    user = _token_lookup(token)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+    return user
+
+
+async def get_admin_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Ensure ``current_user`` has administrative privileges."""
+
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+    return current_user

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,58 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import {
   Alert,
   Box,
+  Chip,
   Container,
   CssBaseline,
   Grid,
   Snackbar,
   Stack,
+  Tab,
+  Tabs,
   Typography
 } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 
 import { API_BASE_DEFAULT } from "./api";
+import AuthPanel from "./components/AuthPanel";
 import ApiConfigPanel from "./components/ApiConfigPanel";
 import RunTaskForm from "./components/RunTaskForm";
 import TaskManagementPanel from "./components/TaskManagementPanel";
 import theme from "./theme";
-import type { NotificationState } from "./types";
+import type {
+  AuthenticatedUser,
+  NotificationState
+} from "./types";
+
+interface TabPanelProps {
+  value: number;
+  index: number;
+  children: ReactNode;
+}
+
+function TabPanel({ value, index, children }: TabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`app-tabpanel-${index}`}
+      aria-labelledby={`app-tab-${index}`}
+    >
+      {value === index ? <Box sx={{ pt: 3 }}>{children}</Box> : null}
+    </div>
+  );
+}
+
+function tabProps(index: number) {
+  return {
+    id: `app-tab-${index}`,
+    "aria-controls": `app-tabpanel-${index}`
+  };
+}
+
+const AUTH_STORAGE_KEY = "ai-testing-tool-auth";
 
 export default function App() {
   const [baseUrl, setBaseUrl] = useState<string>(API_BASE_DEFAULT);
@@ -24,10 +60,52 @@ export default function App() {
     null
   );
   const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState(0);
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<AuthenticatedUser | null>(null);
 
   const showNotification = useCallback((update: NotificationState) => {
     setNotification(update);
     setSnackbarOpen(true);
+  }, []);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(stored) as {
+        token?: string;
+        user?: AuthenticatedUser;
+      };
+      if (parsed.token && parsed.user) {
+        setToken(parsed.token);
+        setUser(parsed.user);
+      }
+    } catch (error) {
+      console.warn("Failed to parse stored authentication", error);
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+    }
+  }, []);
+
+  const handleLogin = useCallback(
+    (accessToken: string, account: AuthenticatedUser) => {
+      setToken(accessToken);
+      setUser(account);
+      localStorage.setItem(
+        AUTH_STORAGE_KEY,
+        JSON.stringify({ token: accessToken, user: account })
+      );
+      setActiveTab((current) => (current === 0 ? 1 : current));
+    },
+    []
+  );
+
+  const handleLogout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem(AUTH_STORAGE_KEY);
   }, []);
 
   function handleSnackbarClose(
@@ -45,32 +123,70 @@ export default function App() {
       <CssBaseline />
       <Container sx={{ py: 4 }}>
         <Stack spacing={4}>
-          <Box>
+          <Stack spacing={1}>
             <Typography variant="h3" component="h1" gutterBottom>
               AI Testing Tool Frontend
             </Typography>
             <Typography variant="subtitle1" color="text.secondary">
               Interact with the FastAPI backend using a modern React interface.
             </Typography>
-          </Box>
-          <Grid container spacing={4}>
-            <Grid item xs={12} md={5}>
-              <ApiConfigPanel
-                baseUrl={baseUrl}
-                onBaseUrlChange={setBaseUrl}
-                onNotify={showNotification}
-              />
+            <Chip
+              label={
+                user
+                  ? `Authenticated as ${user.email} (${user.role})`
+                  : "Not authenticated"
+              }
+              color={user ? "success" : "default"}
+              variant={user ? "filled" : "outlined"}
+            />
+          </Stack>
+          <Tabs
+            value={activeTab}
+            onChange={(_event, value) => setActiveTab(value)}
+            aria-label="Application navigation"
+            variant="scrollable"
+            scrollButtons="auto"
+          >
+            <Tab label="Health" {...tabProps(0)} />
+            <Tab label="Run Tasks" disabled={!token} {...tabProps(1)} />
+            <Tab label="Results" disabled={!token} {...tabProps(2)} />
+          </Tabs>
+          <TabPanel value={activeTab} index={0}>
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                <ApiConfigPanel
+                  baseUrl={baseUrl}
+                  onBaseUrlChange={setBaseUrl}
+                  onNotify={showNotification}
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <AuthPanel
+                  baseUrl={baseUrl}
+                  token={token}
+                  user={user}
+                  onLogin={handleLogin}
+                  onLogout={handleLogout}
+                  onNotify={showNotification}
+                />
+              </Grid>
             </Grid>
-            <Grid item xs={12} md={7}>
-              <RunTaskForm baseUrl={baseUrl} onNotify={showNotification} />
-            </Grid>
-            <Grid item xs={12}>
-              <TaskManagementPanel
-                baseUrl={baseUrl}
-                onNotify={showNotification}
-              />
-            </Grid>
-          </Grid>
+          </TabPanel>
+          <TabPanel value={activeTab} index={1}>
+            <RunTaskForm
+              baseUrl={baseUrl}
+              token={token}
+              onNotify={showNotification}
+            />
+          </TabPanel>
+          <TabPanel value={activeTab} index={2}>
+            <TaskManagementPanel
+              baseUrl={baseUrl}
+              token={token}
+              user={user}
+              onNotify={showNotification}
+            />
+          </TabPanel>
         </Stack>
       </Container>
       <Snackbar

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,22 +3,31 @@ import type { ApiResult } from "./types";
 
 export const API_BASE_DEFAULT = "http://localhost:8090";
 
+type HttpMethod = "get" | "post" | "delete" | "patch";
+
 export async function apiRequest<T = unknown>(
   baseUrl: string,
-  method: "get" | "post",
+  method: HttpMethod,
   path: string,
-  payload?: unknown
+  payload?: unknown,
+  token?: string | null
 ): Promise<ApiResult<T>> {
   const client = axios.create({
     baseURL: baseUrl.replace(/\/$/, ""),
     headers: { "Content-Type": "application/json" }
   });
 
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   try {
     const response = await client.request<T>({
       url: path,
       method,
-      data: payload
+      data: payload,
+      headers
     });
     return {
       ok: true,

--- a/frontend/src/components/AuthPanel.tsx
+++ b/frontend/src/components/AuthPanel.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Paper,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography
+} from "@mui/material";
+import LoginIcon from "@mui/icons-material/Login";
+import PersonAddIcon from "@mui/icons-material/PersonAddAlt1";
+import LogoutIcon from "@mui/icons-material/Logout";
+
+import { apiRequest } from "../api";
+import type {
+  AuthenticatedUser,
+  AuthResponse,
+  NotificationState
+} from "../types";
+
+interface AuthPanelProps {
+  baseUrl: string;
+  token: string | null;
+  user: AuthenticatedUser | null;
+  onLogin: (token: string, user: AuthenticatedUser) => void;
+  onLogout: () => void;
+  onNotify: (notification: NotificationState) => void;
+}
+
+export default function AuthPanel({
+  baseUrl,
+  token,
+  user,
+  onLogin,
+  onLogout,
+  onNotify
+}: AuthPanelProps) {
+  const [mode, setMode] = useState<"login" | "signup">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const isAuthenticated = Boolean(token && user);
+
+  async function handleSubmit() {
+    if (!email.trim() || !password.trim()) {
+      onNotify({ message: "Enter email and password", severity: "warning" });
+      return;
+    }
+
+    setLoading(true);
+    const path = mode === "signup" ? "/auth/signup" : "/auth/login";
+    const result = await apiRequest<AuthResponse>(
+      baseUrl,
+      "post",
+      path,
+      { email: email.trim(), password: password.trim() }
+    );
+    setLoading(false);
+
+    if (!result.ok || !result.data) {
+      const message =
+        result.error ?? `Authentication failed (${result.status})`;
+      onNotify({ message, severity: "error" });
+      return;
+    }
+
+    onLogin(result.data.access_token, result.data.user);
+    onNotify({
+      message:
+        mode === "signup"
+          ? "Account created and logged in"
+          : "Logged in successfully",
+      severity: "success"
+    });
+    setPassword("");
+  }
+
+  async function handleLogout() {
+    if (!token) {
+      onLogout();
+      return;
+    }
+    setLoading(true);
+    const result = await apiRequest(baseUrl, "post", "/auth/logout", undefined, token);
+    setLoading(false);
+    if (!result.ok && result.status !== 0 && result.status !== 204) {
+      const message = result.error ?? `Logout failed (${result.status})`;
+      onNotify({ message, severity: "warning" });
+    } else {
+      onNotify({ message: "Logged out", severity: "success" });
+    }
+    onLogout();
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Stack spacing={3}>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <Typography variant="h5" component="h2">
+            Authentication
+          </Typography>
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={mode}
+            onChange={(_event, value) => {
+              if (value) {
+                setMode(value);
+              }
+            }}
+            disabled={isAuthenticated}
+          >
+            <ToggleButton value="login" aria-label="login mode">
+              <LoginIcon fontSize="small" sx={{ mr: 1 }} /> Log In
+            </ToggleButton>
+            <ToggleButton value="signup" aria-label="signup mode">
+              <PersonAddIcon fontSize="small" sx={{ mr: 1 }} /> Sign Up
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Stack>
+
+        {isAuthenticated && user ? (
+          <Alert severity="success">
+            Logged in as <strong>{user.email}</strong> ({user.role})
+          </Alert>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            Provide your email and password to {mode === "signup" ? "create" : "access"} an
+            account. Passwords must be at least 8 characters when signing up.
+          </Typography>
+        )}
+
+        {!isAuthenticated ? (
+          <Stack spacing={2}>
+            <TextField
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              fullWidth
+              disabled={loading}
+            />
+            <TextField
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              fullWidth
+              disabled={loading}
+            />
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSubmit}
+              disabled={loading}
+              startIcon={mode === "signup" ? <PersonAddIcon /> : <LoginIcon />}
+            >
+              {mode === "signup" ? "Sign Up" : "Log In"}
+            </Button>
+          </Stack>
+        ) : (
+          <Button
+            variant="outlined"
+            color="inherit"
+            onClick={handleLogout}
+            startIcon={<LogoutIcon />}
+            disabled={loading}
+          >
+            Log Out
+          </Button>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/frontend/src/components/RunTaskForm.tsx
+++ b/frontend/src/components/RunTaskForm.tsx
@@ -11,7 +11,11 @@ import {
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 
 import { apiRequest, formatPayload } from "../api";
-import type { NotificationState, RunTaskPayload } from "../types";
+import type {
+  NotificationState,
+  RunResponse,
+  RunTaskPayload
+} from "../types";
 import JsonOutput from "./JsonOutput";
 
 const SAMPLE_TASKS = JSON.stringify(
@@ -27,10 +31,15 @@ const SAMPLE_TASKS = JSON.stringify(
 
 interface RunTaskFormProps {
   baseUrl: string;
+  token: string | null;
   onNotify: (notification: NotificationState) => void;
 }
 
-export default function RunTaskForm({ baseUrl, onNotify }: RunTaskFormProps) {
+export default function RunTaskForm({
+  baseUrl,
+  token,
+  onNotify
+}: RunTaskFormProps) {
   const [prompt, setPrompt] = useState(
     "Describe the tasks for the automation agent."
   );
@@ -43,6 +52,14 @@ export default function RunTaskForm({ baseUrl, onNotify }: RunTaskFormProps) {
   const [response, setResponse] = useState("");
 
   async function handleSubmit() {
+    if (!token) {
+      onNotify({
+        message: "Log in to submit automation tasks",
+        severity: "warning"
+      });
+      return;
+    }
+
     let tasks: unknown[];
     try {
       const parsed = tasksJson ? JSON.parse(tasksJson) : [];
@@ -67,7 +84,13 @@ export default function RunTaskForm({ baseUrl, onNotify }: RunTaskFormProps) {
     };
 
     setSubmitting(true);
-    const result = await apiRequest(baseUrl, "post", "/run", payload);
+    const result = await apiRequest<RunResponse>(
+      baseUrl,
+      "post",
+      "/run",
+      payload,
+      token
+    );
     setSubmitting(false);
 
     if (result.ok) {

--- a/frontend/src/components/TaskManagementPanel.tsx
+++ b/frontend/src/components/TaskManagementPanel.tsx
@@ -1,31 +1,79 @@
-import { useState } from "react";
-import { Button, Stack, TextField, Typography } from "@mui/material";
+import { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardHeader,
+  CardMedia,
+  Divider,
+  Stack,
+  TextField,
+  Typography
+} from "@mui/material";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import TaskIcon from "@mui/icons-material/Task";
 import InsightsIcon from "@mui/icons-material/Insights";
+import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
 
 import { apiRequest, formatPayload } from "../api";
-import type { NotificationState } from "../types";
+import type {
+  AuthenticatedUser,
+  NotificationState,
+  StepInfo,
+  TaskCollectionResponse,
+  TaskStatusResponse
+} from "../types";
 import JsonOutput from "./JsonOutput";
 
 interface TaskManagementPanelProps {
   baseUrl: string;
+  token: string | null;
+  user: AuthenticatedUser | null;
   onNotify: (notification: NotificationState) => void;
+}
+
+function resolveAssetUrl(baseUrl: string, path: string): string {
+  const trimmed = baseUrl.replace(/\/$/, "");
+  return `${trimmed}${path}`;
 }
 
 export default function TaskManagementPanel({
   baseUrl,
+  token,
+  user,
   onNotify
 }: TaskManagementPanelProps) {
   const [tasksContent, setTasksContent] = useState("");
   const [statusContent, setStatusContent] = useState("");
   const [resultContent, setResultContent] = useState("");
   const [taskId, setTaskId] = useState("");
+  const [steps, setSteps] = useState<StepInfo[]>([]);
   const [loading, setLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const assetBase = useMemo(() => baseUrl.replace(/\/$/, ""), [baseUrl]);
+
+  function requireToken(): string | null {
+    if (!token) {
+      onNotify({ message: "Log in to manage tasks", severity: "warning" });
+      return null;
+    }
+    return token;
+  }
 
   async function refreshTasks() {
+    const authToken = requireToken();
+    if (!authToken) {
+      return;
+    }
     setLoading(true);
-    const result = await apiRequest(baseUrl, "get", "/tasks");
+    const result = await apiRequest<TaskCollectionResponse>(
+      baseUrl,
+      "get",
+      "/tasks",
+      undefined,
+      authToken
+    );
     setLoading(false);
     if (result.ok) {
       onNotify({ message: "Fetched tasks", severity: "success" });
@@ -42,8 +90,18 @@ export default function TaskManagementPanel({
       onNotify({ message: "Enter a task ID", severity: "warning" });
       return;
     }
+    const authToken = requireToken();
+    if (!authToken) {
+      return;
+    }
     setLoading(true);
-    const result = await apiRequest(baseUrl, "get", `/tasks/${trimmed}`);
+    const result = await apiRequest<TaskStatusResponse>(
+      baseUrl,
+      "get",
+      `/tasks/${trimmed}`,
+      undefined,
+      authToken
+    );
     setLoading(false);
     if (result.ok) {
       onNotify({ message: "Status retrieved", severity: "success" });
@@ -60,8 +118,18 @@ export default function TaskManagementPanel({
       onNotify({ message: "Enter a task ID", severity: "warning" });
       return;
     }
+    const authToken = requireToken();
+    if (!authToken) {
+      return;
+    }
     setLoading(true);
-    const result = await apiRequest(baseUrl, "get", `/tasks/${trimmed}/result`);
+    const result = await apiRequest<TaskStatusResponse>(
+      baseUrl,
+      "get",
+      `/tasks/${trimmed}/result`,
+      undefined,
+      authToken
+    );
     setLoading(false);
     if (result.ok) {
       onNotify({ message: "Result retrieved", severity: "success" });
@@ -70,24 +138,77 @@ export default function TaskManagementPanel({
       onNotify({ message, severity: "error" });
     }
     setResultContent(formatPayload(result.data));
+    const responseSteps =
+      result.ok && Array.isArray(result.data?.steps)
+        ? (result.data?.steps as StepInfo[])
+        : [];
+    setSteps(responseSteps);
   }
 
+  async function deleteTask() {
+    const trimmed = taskId.trim();
+    if (!trimmed) {
+      onNotify({ message: "Enter a task ID", severity: "warning" });
+      return;
+    }
+    const authToken = requireToken();
+    if (!authToken) {
+      return;
+    }
+    setDeleting(true);
+    const result = await apiRequest(
+      baseUrl,
+      "delete",
+      `/tasks/${trimmed}`,
+      undefined,
+      authToken
+    );
+    setDeleting(false);
+    if (result.ok) {
+      onNotify({ message: "Task deleted", severity: "success" });
+      setStatusContent("");
+      setResultContent("");
+      setSteps([]);
+      await refreshTasks();
+    } else {
+      const message = result.error ?? `Request failed with ${result.status}`;
+      onNotify({ message, severity: "error" });
+    }
+  }
+
+  const disableActions = loading || deleting;
+
   return (
-    <Stack spacing={2}>
+    <Stack spacing={3}>
       <Stack direction="row" spacing={1} alignItems="center">
         <TaskIcon color="primary" />
         <Typography variant="h5" component="h2">
           Task Management
         </Typography>
       </Stack>
-      <Button
-        startIcon={<RefreshIcon />}
-        variant="outlined"
-        onClick={refreshTasks}
-        disabled={loading}
-      >
-        Refresh Tasks
-      </Button>
+      <Typography variant="body2" color="text.secondary">
+        Viewing tasks as {user ? `${user.email} (${user.role})` : "guest"}. Only
+        your own tasks are visible unless you are an administrator.
+      </Typography>
+      <Stack direction="row" spacing={2}>
+        <Button
+          startIcon={<RefreshIcon />}
+          variant="outlined"
+          onClick={refreshTasks}
+          disabled={disableActions}
+        >
+          Refresh Tasks
+        </Button>
+        <Button
+          startIcon={<DeleteForeverIcon />}
+          color="error"
+          variant="outlined"
+          onClick={deleteTask}
+          disabled={disableActions}
+        >
+          Delete Task
+        </Button>
+      </Stack>
       <JsonOutput title="Tasks" content={tasksContent} />
       <TextField
         label="Task ID"
@@ -100,7 +221,7 @@ export default function TaskManagementPanel({
           startIcon={<InsightsIcon />}
           variant="contained"
           onClick={loadStatus}
-          disabled={loading}
+          disabled={disableActions}
         >
           Get Task Status
         </Button>
@@ -108,13 +229,48 @@ export default function TaskManagementPanel({
           variant="contained"
           color="secondary"
           onClick={loadResult}
-          disabled={loading}
+          disabled={disableActions}
         >
           Get Task Result
         </Button>
       </Stack>
       <JsonOutput title="Status" content={statusContent} />
       <JsonOutput title="Result" content={resultContent} />
+      <Divider />
+      <Stack spacing={2}>
+        <Typography variant="h6">Execution Steps</Typography>
+        {steps.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            {resultContent
+              ? "No screenshots were reported for this task."
+              : "Run a task result query to view captured screenshots."}
+          </Typography>
+        ) : (
+          <Stack spacing={2}>
+            {steps.map((step) => (
+              <Card key={`${taskId}-${step.index}`} variant="outlined">
+                <CardHeader
+                  title={`Step ${step.index + 1}`}
+                  subheader={step.filename}
+                />
+                <Box px={2} pb={2}>
+                  <CardMedia
+                    component="img"
+                    image={resolveAssetUrl(assetBase, step.image_url)}
+                    alt={`Step ${step.index + 1} screenshot`}
+                    sx={{
+                      maxHeight: 420,
+                      borderRadius: 1,
+                      border: (theme) => `1px solid ${theme.palette.divider}`,
+                      objectFit: "contain"
+                    }}
+                  />
+                </Box>
+              </Card>
+            ))}
+          </Stack>
+        )}
+      </Stack>
     </Stack>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,18 @@ export interface ApiResult<T = unknown> {
   error?: string;
 }
 
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  role: string;
+}
+
+export interface AuthResponse {
+  access_token: string;
+  token_type: string;
+  user: AuthenticatedUser;
+}
+
 export interface RunTaskPayload {
   prompt: string;
   tasks: unknown[];
@@ -19,4 +31,31 @@ export interface RunTaskPayload {
 export interface NotificationState {
   message: string;
   severity: AlertColor;
+}
+
+export interface StepInfo {
+  index: number;
+  filename: string;
+  image_url: string;
+}
+
+export interface TaskStatusResponse {
+  task_id: string;
+  status: "pending" | "running" | "completed" | "failed";
+  summary?: unknown;
+  summary_path?: string | null;
+  error?: string | null;
+  owner_id?: string | null;
+  steps?: StepInfo[];
+}
+
+export interface TaskCollectionResponse {
+  completed: string[];
+  pending: string[];
+  running: string[];
+  error: string[];
+}
+
+export interface RunResponse {
+  task_id: string;
 }


### PR DESCRIPTION
## Summary
- add SQLite-backed authentication endpoints, token validation, and user-scoped task/result APIs with screenshot metadata and static report hosting
- propagate task ownership through the queue runner so status updates keep user identifiers
- refresh the React UI with tabbed navigation, login/signup flows, authenticated API calls, and step-by-step result galleries sourced from reports

## Testing
- pytest
- pre-commit run --files ai_testing_tool/api.py ai_testing_tool/queue_runner.py frontend/src/App.tsx frontend/src/api.ts frontend/src/components/RunTaskForm.tsx frontend/src/components/TaskManagementPanel.tsx frontend/src/types.ts frontend/src/components/AuthPanel.tsx *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c22b2354832a9c04882cf8ac69d1