### PR TITLE
Enhance frontend layout and task handling

### DIFF
--- a/ai_testing_tool/api.py
+++ b/ai_testing_tool/api.py
@@ -404,7 +404,7 @@ app.add_middleware(
 
 app.mount(
     "/reports",
-    StaticFiles(directory="./reports", html=False, check_dir=False),
+    StaticFiles(directory=str(_REPORTS_ROOT), html=False, check_dir=False),
     name="reports",
 )
 
@@ -622,7 +622,7 @@ def _step_candidates(directory: Path) -> Iterable[Path]:
     """Yield potential screenshot files from ``directory``."""
 
     for extension in ("png", "jpg", "jpeg"):
-        yield from directory.glob(f"step_*.{extension}")
+        yield from directory.rglob(f"step_*.{extension}")
 
 
 def _build_step_images(summary_path: Optional[str]) -> List[StepInfo]:
@@ -642,6 +642,8 @@ def _build_step_images(summary_path: Optional[str]) -> List[StepInfo]:
 
     chosen: Dict[int, Path] = {}
     for candidate in _step_candidates(directory):
+        if not candidate.is_file():
+            continue
         match = re.search(r"step_(\d+)", candidate.name)
         if not match:
             continue

--- a/ai_testing_tool/queue_runner.py
+++ b/ai_testing_tool/queue_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import signal
 from typing import Any, Dict, Optional
 
@@ -39,13 +40,16 @@ def _process_task(redis_client: Any, raw_task: str) -> None:
     owner_id: Optional[str] = task.get("user_id")
     _update_status(redis_client, task_id, {"status": "running"}, owner_id)
 
+    reports_folder = task.get("reports_folder") or "./reports"
+    task_reports_folder = os.path.join(reports_folder, task_id)
+
     try:
         result = _run_tasks(
             task["prompt"],
             task["tasks"],
             task["server"],
             task["platform"],
-            task["reports_folder"],
+            task_reports_folder,
             task["debug"],
         )
     except Exception as exc:  # pragma: no cover - background safety net

--- a/frontend/src/components/AuthPanel.tsx
+++ b/frontend/src/components/AuthPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Alert,
   Button,
@@ -27,6 +27,8 @@ interface AuthPanelProps {
   onLogin: (token: string, user: AuthenticatedUser) => void;
   onLogout: () => void;
   onNotify: (notification: NotificationState) => void;
+  activeMode?: "login" | "signup";
+  onModeChange?: (mode: "login" | "signup") => void;
 }
 
 export default function AuthPanel({
@@ -35,7 +37,9 @@ export default function AuthPanel({
   user,
   onLogin,
   onLogout,
-  onNotify
+  onNotify,
+  activeMode,
+  onModeChange
 }: AuthPanelProps) {
   const [mode, setMode] = useState<"login" | "signup">("login");
   const [email, setEmail] = useState("");
@@ -43,6 +47,12 @@ export default function AuthPanel({
   const [loading, setLoading] = useState(false);
 
   const isAuthenticated = Boolean(token && user);
+
+  useEffect(() => {
+    if (activeMode && activeMode !== mode) {
+      setMode(activeMode);
+    }
+  }, [activeMode, mode]);
 
   async function handleSubmit() {
     if (!email.trim() || !password.trim()) {
@@ -109,6 +119,7 @@ export default function AuthPanel({
             onChange={(_event, value) => {
               if (value) {
                 setMode(value);
+                onModeChange?.(value);
               }
             }}
             disabled={isAuthenticated}

--- a/frontend/src/components/RunTaskForm.tsx
+++ b/frontend/src/components/RunTaskForm.tsx
@@ -29,6 +29,102 @@ const SAMPLE_TASKS = JSON.stringify(
   2
 );
 
+const DEFAULT_PROMPT = `# Role
+You are a mobile automation testing assistant. 
+
+# Task
+Your job is to determine the next course of action for the task given to you. 
+
+The set of actions that you are able to take are tap, input, swipe, wait, error, or finish. Their format should be JSON. For example:
+
+- {"action": "tap","xpath": "//[@text='Battery']", "explanation": "I need to tap the Battery button to check battery details. I can see the xpath of the button is //[@text='Battery'], So I will use it to find the button and tap it"}
+- {"action": "tap","bounds": "[22,1117][336,1227]", "explanation": "I need to tap the Battery button to check battery details. I can see the bounds of the button is [22,1117][336,1227], So I will use it to find the button and tap it"}
+- {"action": "input","xpath": "//[@id='user']", "value": "test user name","explanation": "I need to input the username to sign in. I can see the xpath of the user input box is //[@id='user'], So I will it to find the user input box"}
+- {"action": "input","bounds": "[22,1117][336,1227]", "value": "test user name","explanation": "I need to input the username to sign in. I can see the bounds of the user input box is [22,1117][336,1227], So I will it to find the user input box"}
+- {"action": "swipe", "swipe_start_x": 10,"swipe_start_y": 30,"swipe_end_x": 20,"swipe_end_y": 30, "duration": 500,"explanation": "I want to move the movie to the highlighted time. So, I will retrieve the start position and end position according to the bounds of elements in source, and return them as (swipe_start_x, swipe_start_y) and (swipe_end_x, swipe_end_y)."} // Example for horizontal swipe, Duration in milliseconds
+- {"action": "wait","timeout": 5000,"explanation": "I can see that there is no meaningful content, So wait a moment for content loading"} // Timeout in milliseconds
+- {"action": "error","message": "there is an unexpected content","explanation": "I saw an unexpected content"}
+- {"action": "finish","explanation": "I saw the expected content"}
+
+# Instructions
+
+You will be presented with the screenshot of the current page you are on.
+
+You will be presented with the source of the current page you are on. You can use the source to determine the xpath or bounds of element, or determine the swipe position.
+
+You will be presented with the history of actions. You can use the history of actions to check the result of previous actions and determine the next action. 
+
+You will follow the following PlantUML to determine the next action. 
+
+"""
+@startuml
+
+start
+
+if (Has the task been completed according to the screenshot?) then (yes)
+    :Generate finish action;
+else (no)
+    if (Has the last action been successful, but the page has not changed? or Is the page loading?) then (yes)
+        :Generate wait action which mean we need to wait a moment for the page to change or load;
+    else (no)
+        if (Is there any unexpected content in screenshot according to the history of actions?) then (yes)
+            :Generate error action which mean there is an unexpected content;
+        else (no)
+            :Inference the next action of the task according to the current screenshot and the history of actions;
+            if (Is the next action tapping an element on the screen?) then (yes)
+               :Check the result of the last action to fix the tap action error;
+               if (Is there bounds attribute in the target element) then (yes)
+                  :Get the bounds attribute of the target element from source;
+                  :Generate tap action with bounds;
+               else (no)
+                  :Get the xpath of the target element from source and ensure the xpath can identify one and only one element;
+                  :Generate tap action with xpath;
+               endif
+            else (no)
+                if (Is the next action inputting text in an element on the screen?) then (yes)
+                  :Check the result of the last action to fix the input action error;
+                  if (Is there bounds attribute in the target element) then (yes)
+                      :Get the bounds attribute of the target element from source;
+                      :Generate input action with bounds;
+                  else (no)
+                      :Get the xpath of the target element from source and ensure the xpath can identify one and only one element;
+                      :Generate input action with xpath;
+                  endif
+                else (no)
+                    if (Is the next action swiping screen?) then (yes)
+                      :Figure out the swipe start position according to the bounds of elements in source;
+                      :Figure out the swipe end position according to the bounds of elements in source;
+                      :Generate swipe action;
+                    else (no)
+                        if (Is next action wait?) then (yes)
+                          :Generate wait action which mean we need to wait a moment for meaningful content;
+                        else (no)
+                          :Generate error action which mean there is no available action to describe the next step;
+                        endif
+                    endif
+                endif
+            endif
+        endif
+    endif
+endif
+
+:Summarize the action in JSON format;
+
+stop
+
+@enduml
+"""
+
+The output should only contain the raw json of actions without code block, and the action should not contain field "result".
+The swipe action should use the element bounds in source to determine the start and end position.`;
+
+type PromptOption = "default" | "web" | "custom";
+
+const PROMPT_TEMPLATES: Record<Exclude<PromptOption, "custom">, string> = {
+  default: DEFAULT_PROMPT,
+  web: DEFAULT_PROMPT
+};
+
 interface RunTaskFormProps {
   baseUrl: string;
   token: string | null;
@@ -40,9 +136,8 @@ export default function RunTaskForm({
   token,
   onNotify
 }: RunTaskFormProps) {
-  const [prompt, setPrompt] = useState(
-    "Describe the tasks for the automation agent."
-  );
+  const [promptOption, setPromptOption] = useState<PromptOption>("default");
+  const [customPrompt, setCustomPrompt] = useState("");
   const [tasksJson, setTasksJson] = useState(SAMPLE_TASKS);
   const [server, setServer] = useState("http://localhost:4723");
   const [platform, setPlatform] = useState("android");
@@ -51,10 +146,23 @@ export default function RunTaskForm({
   const [submitting, setSubmitting] = useState(false);
   const [response, setResponse] = useState("");
 
+  const promptValue =
+    promptOption === "custom"
+      ? customPrompt
+      : PROMPT_TEMPLATES[promptOption];
+
   async function handleSubmit() {
     if (!token) {
       onNotify({
         message: "Log in to submit automation tasks",
+        severity: "warning"
+      });
+      return;
+    }
+
+    if (!promptValue.trim()) {
+      onNotify({
+        message: "Select or enter a prompt for the automation assistant",
         severity: "warning"
       });
       return;
@@ -75,7 +183,7 @@ export default function RunTaskForm({
     }
 
     const payload: RunTaskPayload = {
-      prompt,
+      prompt: promptValue,
       tasks,
       server,
       platform,
@@ -111,12 +219,35 @@ export default function RunTaskForm({
         </Typography>
       </Stack>
       <TextField
-        label="Prompt"
-        value={prompt}
-        onChange={(event) => setPrompt(event.target.value)}
+        select
+        label="Prompt Template"
+        value={promptOption}
+        onChange={(event) =>
+          setPromptOption(event.target.value as PromptOption)
+        }
+        fullWidth
+      >
+        <MenuItem value="default">Default prompt</MenuItem>
+        <MenuItem value="web">Web prompt</MenuItem>
+        <MenuItem value="custom">Custom prompt</MenuItem>
+      </TextField>
+      <TextField
+        label={promptOption === "custom" ? "Custom Prompt" : "Prompt"}
+        value={promptValue}
+        onChange={(event) => {
+          if (promptOption === "custom") {
+            setCustomPrompt(event.target.value);
+          }
+        }}
         fullWidth
         multiline
-        minRows={3}
+        minRows={6}
+        InputProps={{ readOnly: promptOption !== "custom" }}
+        helperText={
+          promptOption === "custom"
+            ? "Provide your own instructions for the automation assistant."
+            : "Selected template preview."
+        }
       />
       <TextField
         label="Tasks (JSON list)"


### PR DESCRIPTION
## Summary
- restyle the app shell with an AppBar-based header and quick auth navigation, keeping the Auth panel in sync with header actions
- add prompt template selection (default, web, or custom) when running automation tasks and validate that a prompt is provided
- replace the raw JSON task list with an interactive table that supports per-task deletion while updating the backend to store reports per task and discover nested screenshots

## Testing
- pytest
- npm run lint *(fails: unable to install frontend dependencies due to npm registry 403 responses)*
- pre-commit run --files ai_testing_tool/api.py ai_testing_tool/queue_runner.py frontend/src/App.tsx frontend/src/components/AuthPanel.tsx frontend/src/components/RunTaskForm.tsx frontend/src/components/TaskManagementPanel.tsx *(fails: pre-commit could not be installed because pip access to PyPI is blocked by a 403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d5a5e85c832abe47f87da4c64034