### PR TITLE
Add Dockerfiles for frontend, API, and queue runner services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+build
+.dist
+*.egg-info
+frontend/node_modules

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libjpeg62-turbo-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ai_testing_tool ./ai_testing_tool
+COPY ai-testing-tool.py ./
+
+ENV PYTHONPATH=/app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "ai_testing_tool.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.queue
+++ b/Dockerfile.queue
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libjpeg62-turbo-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ai_testing_tool ./ai_testing_tool
+COPY ai-testing-tool.py ./
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "ai_testing_tool/queue_runner.py"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add a production-ready multi-stage Dockerfile for the Vite frontend
- create Dockerfiles for the FastAPI service and background queue runner
- add dockerignore files to keep build contexts minimal

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d189d6d85c832ab75b7eeda0600523