### PR TITLE
Add repeat runs and grouped task management UI

### DIFF
--- a/frontend_server/src/App.tsx
+++ b/frontend_server/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { ReactNode, SyntheticEvent } from "react";
 import {
   Alert,
   AppBar,
@@ -10,6 +10,7 @@ import {
   CssBaseline,
   Grid,
   Snackbar,
+  SnackbarCloseReason,
   Stack,
   Tab,
   Tabs,
@@ -125,8 +126,8 @@ export default function App() {
   }, []);
 
   function handleSnackbarClose(
-    _event?: unknown,
-    reason?: "timeout" | "clickaway"
+    _event?: Event | SyntheticEvent,
+    reason?: SnackbarCloseReason
   ) {
     if (reason === "clickaway") {
       return;
@@ -255,7 +256,7 @@ export default function App() {
           >
             {notification.message}
           </Alert>
-        ) : null}
+        ) : undefined}
       </Snackbar>
     </ThemeProvider>
   );

--- a/frontend_server/src/components/JsonOutput.tsx
+++ b/frontend_server/src/components/JsonOutput.tsx
@@ -9,6 +9,8 @@ import {
 } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import CheckIcon from "@mui/icons-material/CheckCircle";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 
 interface JsonOutputProps {
   title: string;
@@ -22,6 +24,10 @@ export default function JsonOutput({
   minHeight = 180
 }: JsonOutputProps) {
   const [copied, setCopied] = useState(false);
+  const [fontSize, setFontSize] = useState(13);
+
+  const canZoomIn = fontSize < 24;
+  const canZoomOut = fontSize > 10;
 
   async function handleCopy() {
     if (!content || !navigator.clipboard) {
@@ -36,6 +42,14 @@ export default function JsonOutput({
     }
   }
 
+  function handleZoomIn() {
+    setFontSize((size) => Math.min(size + 2, 24));
+  }
+
+  function handleZoomOut() {
+    setFontSize((size) => Math.max(size - 2, 10));
+  }
+
   return (
     <Paper variant="outlined">
       <Stack spacing={1} p={2} height={minHeight}>
@@ -43,18 +57,48 @@ export default function JsonOutput({
           <Typography variant="subtitle1" fontWeight={600}>
             {title}
           </Typography>
-          <Tooltip title={copied ? "Copied" : "Copy"} placement="left">
-            <span>
-              <IconButton
-                aria-label="copy-json"
-                size="small"
-                disabled={!content}
-                onClick={handleCopy}
-              >
-                {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
-              </IconButton>
-            </span>
-          </Tooltip>
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            <Tooltip title="Zoom out" placement="left">
+              <span>
+                <IconButton
+                  aria-label="zoom-out"
+                  size="small"
+                  onClick={handleZoomOut}
+                  disabled={!canZoomOut}
+                >
+                  <ZoomOutIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Zoom in" placement="left">
+              <span>
+                <IconButton
+                  aria-label="zoom-in"
+                  size="small"
+                  onClick={handleZoomIn}
+                  disabled={!canZoomIn}
+                >
+                  <ZoomInIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title={copied ? "Copied" : "Copy"} placement="left">
+              <span>
+                <IconButton
+                  aria-label="copy-json"
+                  size="small"
+                  disabled={!content}
+                  onClick={handleCopy}
+                >
+                  {copied ? (
+                    <CheckIcon fontSize="small" />
+                  ) : (
+                    <ContentCopyIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </span>
+            </Tooltip>
+          </Stack>
         </Stack>
         <Box
           component="pre"
@@ -66,7 +110,8 @@ export default function JsonOutput({
             borderRadius: 1,
             overflow: "auto",
             fontFamily: "Roboto Mono, monospace",
-            fontSize: 13
+            fontSize,
+            lineHeight: 1.5
           }}
         >
           {content || "No data"}

--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -26,6 +26,7 @@ export interface RunTaskPayload {
   platform: string;
   reports_folder: string;
   debug: boolean;
+  repeat: number;
 }
 
 export interface NotificationState {
@@ -49,13 +50,19 @@ export interface TaskStatusResponse {
   steps?: StepInfo[];
 }
 
+export interface TaskListEntry {
+  task_id: string;
+  task_name: string;
+}
+
 export interface TaskCollectionResponse {
-  completed: string[];
-  pending: string[];
-  running: string[];
-  error: string[];
+  completed: TaskListEntry[];
+  pending: TaskListEntry[];
+  running: TaskListEntry[];
+  error: TaskListEntry[];
 }
 
 export interface RunResponse {
   task_id: string;
+  task_ids: string[];
 }


### PR DESCRIPTION
## Summary
- add repeat count support to the run endpoint while returning the ids for all enqueued runs and resolving task names when listing queues
- expose task names to the frontend, group queued runs by task name, and add zoom controls to status/result viewers
- update the run form to copy built-in prompts, hide the template text area, and allow configuring repeat counts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ca2fdfd4832ab537994fd8518e66