### PR TITLE
Improve HTTPS configuration for frontend server

### DIFF
--- a/frontend_server/nginx.conf
+++ b/frontend_server/nginx.conf
@@ -1,19 +1,15 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name _;
+    server_name ai-ui-test.qa.fortinet-us.com _;
 
-    root /usr/share/nginx/html;
-    index index.html;
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
+    return 301 https://$host$request_uri;
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name ai-ui-test.qa.fortinet-us.com _;
 
     ssl_certificate /etc/nginx/certs/tls.crt;


### PR DESCRIPTION
## Summary
- redirect HTTP traffic to HTTPS for the ai-ui-test.qa.fortinet-us.com host
- update the nginx configuration to use the modern `http2 on;` directive to clear startup warnings

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68db169aad1c832aa3aaf2d0f3361b21