### PR TITLE
Improve default API base URL handling for HTTPS

### DIFF
--- a/frontend_server/src/api.ts
+++ b/frontend_server/src/api.ts
@@ -1,7 +1,23 @@
 import axios, { AxiosError } from "axios";
 import type { ApiResult } from "./types";
 
-export const API_BASE_DEFAULT = "http://10.160.13.110:8090";
+function resolveDefaultApiBase(): string {
+  const envBase = import.meta?.env?.VITE_API_BASE_URL;
+  if (typeof envBase === "string" && envBase.trim()) {
+    return envBase.trim().replace(/\/$/, "");
+  }
+
+  if (typeof window !== "undefined") {
+    const { origin, protocol } = window.location;
+    if (protocol === "https:") {
+      return origin.replace(/\/$/, "");
+    }
+  }
+
+  return "http://10.160.13.110:8090";
+}
+
+export const API_BASE_DEFAULT = resolveDefaultApiBase();
 
 type HttpMethod = "get" | "post" | "delete" | "patch";
 


### PR DESCRIPTION
## Summary
- add logic to derive the default API base URL from an environment variable when available
- fall back to the current HTTPS origin before using the legacy HTTP endpoint to avoid mixed-content errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3ffc5888832ab6b72e7e017d57ad