### PR TITLE
Add configurable TLS support for backend API

### DIFF
--- a/backend_server/README.md
+++ b/backend_server/README.md
@@ -59,6 +59,25 @@ curl -X POST "http://<server-ip>:8090/run" \
 The response returns the aggregated summary along with the path to the generated
 `summary.json` report inside the reports directory.
 
+### Enabling HTTPS/TLS
+
+The backend can serve traffic over HTTPS by providing certificate details through
+environment variables when launching the API (either with `python
+backend_server/api.py` or via Uvicorn directly):
+
+```sh
+APP_SSL_CERTFILE=/path/to/cert.pem \
+APP_SSL_KEYFILE=/path/to/key.pem \
+APP_SSL_CA_CERTS=/path/to/ca-bundle.pem \  # optional
+APP_SSL_KEYFILE_PASSWORD=secret \          # optional
+python -m backend_server.api
+```
+
+Both `APP_SSL_CERTFILE` and `APP_SSL_KEYFILE` must be supplied to enable TLS.
+Optional `APP_SSL_CA_CERTS` and `APP_SSL_KEYFILE_PASSWORD` values are respected
+when present. When these variables are set the server automatically exposes HTTPS
+on the configured port.
+
 ## Web Frontend
 
 A modern React and TypeScript frontend is available in the `frontend_server/` directory.


### PR DESCRIPTION
## Summary
- add environment-driven TLS configuration to the FastAPI entrypoint
- validate SSL file paths and pass the configuration through to Uvicorn
- document HTTPS setup steps in the backend README

## Testing
- python -m compileall backend_server

------
https://chatgpt.com/codex/tasks/task_e_68db5d4bb900832a8c605dd92fe8abbf