### PR TITLE
Persist SQLite database via Docker volume

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,6 +7,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # This is your "cd"
 WORKDIR /app
 
+# Location for persistent application data such as the SQLite database.
+RUN mkdir -p /data
+ENV AITOOL_DB_PATH=/data/auth.db
+VOLUME ["/data"]
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       build-essential \

--- a/Dockerfile.queue
+++ b/Dockerfile.queue
@@ -6,6 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Location for persistent application data such as the SQLite database.
+RUN mkdir -p /data
+ENV AITOOL_DB_PATH=/data/auth.db
+VOLUME ["/data"]
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
## Summary
- create a dedicated /data directory in the API and queue Docker images
- configure the backend to store its SQLite database at /data/auth.db
- declare a Docker volume so the database can be mounted from outside the container for persistence

## Testing
- not run (Dockerfile-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc09a3b058832ab86e332ff38ac1b3