### PR TITLE
Normalize API base URLs without a scheme

### DIFF
--- a/frontend_server/src/api.ts
+++ b/frontend_server/src/api.ts
@@ -5,6 +5,19 @@ export const API_BASE_DEFAULT = "http://ai-ui-test.qa.fortinet-us.com:8090";
 
 type HttpMethod = "get" | "post" | "delete" | "patch";
 
+function normaliseBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed);
+  if (hasScheme) {
+    return trimmed;
+  }
+  return `http://${trimmed}`;
+}
+
 export async function apiRequest<T = unknown>(
   baseUrl: string,
   method: HttpMethod,
@@ -12,8 +25,9 @@ export async function apiRequest<T = unknown>(
   payload?: unknown,
   token?: string | null
 ): Promise<ApiResult<T>> {
+  const baseURL = normaliseBaseUrl(baseUrl).replace(/\/$/, "");
   const client = axios.create({
-    baseURL: baseUrl.replace(/\/$/, ""),
+    baseURL,
     headers: { "Content-Type": "application/json" }
   });
 


### PR DESCRIPTION
## Summary
- ensure axios requests default to http:// when the configured API URL is missing a scheme
- create a normalisation helper so user-supplied hosts no longer fall back to the page protocol

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc33e0e958832a91f427577d72861b