### PR TITLE
Add centralized logging and docker compose orchestration

### DIFF
--- a/backend_server/README.md
+++ b/backend_server/README.md
@@ -105,6 +105,22 @@ npm run build
 which outputs static assets in `frontend_server/dist/`. Use `npm run preview` to test the
 production build locally.
 
+## Running the full stack with Docker Compose
+
+The repository now ships with a `docker-compose.yml` file that builds and launches
+the FastAPI backend, Redis queue worker, Redis itself, and the production Nginx
+frontend. The services share persistent volumes for the SQLite database and Redis
+data. To start everything with the Docker CLI, run:
+
+```sh
+docker compose up --build
+```
+
+The command exposes the API at `https://localhost:8090` (if TLS certificates are
+provided) and the frontend at `http://localhost:5173`. Environment variables such
+as `BACKEND_LOG_LEVEL` can be supplied to adjust logging verbosity for the backend
+and queue worker containers.
+
 
 ## Acknowledgements
 

--- a/backend_server/__init__.py
+++ b/backend_server/__init__.py
@@ -1,0 +1,7 @@
+"""Backend server package exposing automation orchestration utilities."""
+
+from backend_server.logging_config import configure_logging
+
+configure_logging()
+
+__all__ = ["configure_logging"]

--- a/backend_server/api.py
+++ b/backend_server/api.py
@@ -15,6 +15,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set
 
+import logging
+
 from fastapi import Depends, FastAPI, Header, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -37,6 +39,8 @@ from backend_server.task_store import (
     register_task_run,
     set_task_status,
 )
+
+logger = logging.getLogger(__name__)
 
 # -----------------------------
 # Database & Auth helpers
@@ -468,11 +472,7 @@ def _ensure_reports_folder() -> None:
     try:
         _REPORTS_ROOT.mkdir(parents=True, exist_ok=True)
     except Exception as exc:  # pragma: no cover - filesystem issue
-        warning = "[WARN] Failed to create reports folder '%s': %s" % (
-            _REPORTS_ROOT,
-            exc,
-        )
-        print(warning)
+        logger.warning("Failed to create reports folder '%s': %s", _REPORTS_ROOT, exc)
 
 
 @app.on_event("startup")

--- a/backend_server/logging_config.py
+++ b/backend_server/logging_config.py
@@ -1,0 +1,83 @@
+"""Centralised logging configuration for the backend server package."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable
+
+_LOGGING_FORMAT = (
+    "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+)
+
+
+def _coerce_level(value: str) -> int:
+    """Return a valid logging level for ``value``.
+
+    Defaults to :data:`logging.INFO` when ``value`` is not recognised.
+    """
+
+    if not value:
+        return logging.INFO
+    if isinstance(value, str):
+        numeric = getattr(logging, value.upper(), None)
+        if isinstance(numeric, int):
+            return numeric
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return logging.INFO
+        return parsed
+    if isinstance(value, int):
+        return value
+    return logging.INFO
+
+
+def _build_handlers(log_file: str | None) -> Iterable[logging.Handler]:
+    """Return the logging handlers to use for configuration."""
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(logging.Formatter(_LOGGING_FORMAT))
+    handlers = [stream_handler]
+
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(logging.Formatter(_LOGGING_FORMAT))
+        handlers.append(file_handler)
+
+    return handlers
+
+
+_configured = False
+
+
+def configure_logging(force: bool = False) -> None:
+    """Initialise logging for the backend package.
+
+    The configuration honours the following environment variables:
+
+    ``BACKEND_LOG_LEVEL``
+        Specifies the root logging level (defaults to ``INFO``).
+    ``BACKEND_LOG_FILE``
+        Optional path to a file where logs should be written in addition to
+        standard output.
+    """
+
+    global _configured
+    if _configured and not force:
+        return
+
+    level = _coerce_level(os.getenv("BACKEND_LOG_LEVEL", "INFO"))
+    log_file = os.getenv("BACKEND_LOG_FILE")
+
+    handlers = list(_build_handlers(log_file))
+    root_logger = logging.getLogger()
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    root_logger.setLevel(level)
+    for handler in handlers:
+        root_logger.addHandler(handler)
+
+    _configured = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    image: ai-testing-tool-api
+    ports:
+      - "8090:8090"
+    environment:
+      REDIS_URL: redis://redis:6379/0
+      BACKEND_LOG_LEVEL: ${BACKEND_LOG_LEVEL:-INFO}
+    volumes:
+      - backend-data:/data
+    depends_on:
+      - redis
+
+  queue:
+    build:
+      context: .
+      dockerfile: Dockerfile.queue
+    image: ai-testing-tool-queue
+    environment:
+      REDIS_URL: redis://redis:6379/0
+      BACKEND_LOG_LEVEL: ${BACKEND_LOG_LEVEL:-INFO}
+    volumes:
+      - backend-data:/data
+    depends_on:
+      - redis
+
+  frontend:
+    build:
+      context: ./frontend_server
+    image: ai-testing-tool-frontend
+    ports:
+      - "5173:80"
+    depends_on:
+      - api
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+volumes:
+  backend-data:
+  redis-data:


### PR DESCRIPTION
## Summary
- add a reusable logging configuration module and initialise it across the backend package
- replace ad-hoc printing with structured logger calls throughout the backend services and libraries
- introduce a docker-compose stack for the API, queue worker, frontend, and Redis and document how to launch it

## Testing
- python -m compileall backend_server

------
https://chatgpt.com/codex/tasks/task_e_68dc43573380832a8a1d0c7f7f41d4fc