### PR TITLE
Add timestamp metadata to task management overview

### DIFF
--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -53,6 +53,8 @@ export interface TaskStatusResponse {
 export interface TaskListEntry {
   task_id: string;
   task_name: string;
+  created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export interface TaskCollectionResponse {


### PR DESCRIPTION
## Summary
- add created and updated timestamps to task list responses and store run metadata when collecting tasks
- surface the new timestamps in the task management UI and show contextual tooltips

## Testing
- npm --prefix frontend_server run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6dbaa9c8832a968a33b3a8bf1a64