### PR TITLE
Add configurable LLM mode with vision support

### DIFF
--- a/backend_server/api.py
+++ b/backend_server/api.py
@@ -328,6 +328,14 @@ class Platform(str, Enum):
     web = "web"
 
 
+class LlmMode(str, Enum):
+    """Inference modes for the action generation model."""
+
+    auto = "auto"
+    text = "text"
+    vision = "vision"
+
+
 class RunRequest(BaseModel):
     """Request payload for running automation tasks."""
 
@@ -356,6 +364,10 @@ class RunRequest(BaseModel):
         ge=1,
         le=500,
         description="Number of times to enqueue the same task run.",
+    )
+    llm_mode: LlmMode = Field(
+        LlmMode.auto,
+        description="Preferred model mode: auto-select, text-only, or vision-enabled.",
     )
 
 

--- a/backend_server/queue_runner.py
+++ b/backend_server/queue_runner.py
@@ -65,6 +65,7 @@ def _process_task(redis_client: Any, raw_task: str) -> None:
             reports_folder,
             task["debug"],
             task_id=task_id,
+            llm_mode=task.get("llm_mode"),
         )
     except Exception as exc:  # pragma: no cover - background safety net
         logger.exception("Task %s failed: %s", task_id, exc)

--- a/frontend_server/src/components/RunTaskForm.tsx
+++ b/frontend_server/src/components/RunTaskForm.tsx
@@ -13,6 +13,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 import { apiRequest, formatPayload } from "../api";
 import type {
+  LlmMode,
   NotificationState,
   RunResponse,
   RunTaskPayload
@@ -66,6 +67,7 @@ export default function RunTaskForm({
   const [response, setResponse] = useState("");
   const [repeatCount, setRepeatCount] = useState(1);
   const [promptCopied, setPromptCopied] = useState(false);
+  const [llmMode, setLlmMode] = useState<LlmMode>("auto");
 
   const promptValue =
     promptOption === "custom"
@@ -147,7 +149,8 @@ export default function RunTaskForm({
       platform,
       reports_folder: reportsFolder,
       debug,
-      repeat: repeatCount
+      repeat: repeatCount,
+      llm_mode: llmMode
     };
 
     setSubmitting(true);
@@ -247,6 +250,18 @@ export default function RunTaskForm({
         <MenuItem value="android">Android</MenuItem>
         <MenuItem value="ios">iOS</MenuItem>
         <MenuItem value="web">Web</MenuItem>
+      </TextField>
+      <TextField
+        select
+        label="LLM Mode"
+        value={llmMode}
+        onChange={(event) => setLlmMode(event.target.value as LlmMode)}
+        fullWidth
+        helperText="Choose whether to auto-detect, force text-only, or use the vision model."
+      >
+        <MenuItem value="auto">Auto (detect from task)</MenuItem>
+        <MenuItem value="text">Text only</MenuItem>
+        <MenuItem value="vision">Vision enabled</MenuItem>
       </TextField>
       <TextField
         label="Reports Folder"

--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -7,6 +7,8 @@ export interface ApiResult<T = unknown> {
   error?: string;
 }
 
+export type LlmMode = "auto" | "text" | "vision";
+
 export interface AuthenticatedUser {
   id: string;
   email: string;
@@ -27,6 +29,7 @@ export interface RunTaskPayload {
   reports_folder: string;
   debug: boolean;
   repeat: number;
+  llm_mode: LlmMode;
 }
 
 export interface NotificationState {


### PR DESCRIPTION
## Summary
- allow automation run requests to choose an LLM mode and persist the selection
- update next-action generation to auto-detect vision needs and call the correct OpenAI endpoint
- expose the LLM mode option in the web form and payload typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd81074ccc832aa85cd170889b4fc7