### PR TITLE
Add dark mode toggle to frontend interface

### DIFF
--- a/frontend_server/src/theme.ts
+++ b/frontend_server/src/theme.ts
@@ -1,22 +1,35 @@
+import type { PaletteMode } from "@mui/material";
 import { createTheme } from "@mui/material/styles";
 
-const theme = createTheme({
-  palette: {
-    mode: "light",
-    primary: {
-      main: "#1976d2"
+const PRIMARY_MAIN = "#1976d2";
+const SECONDARY_MAIN = "#9c27b0";
+
+export function createAppTheme(mode: PaletteMode) {
+  return createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: PRIMARY_MAIN
+      },
+      secondary: {
+        main: SECONDARY_MAIN
+      },
+      background:
+        mode === "dark"
+          ? {
+              default: "#0b0e12",
+              paper: "#161b22"
+            }
+          : undefined
     },
-    secondary: {
-      main: "#9c27b0"
-    }
-  },
-  components: {
-    MuiContainer: {
-      defaultProps: {
-        maxWidth: "lg"
+    components: {
+      MuiContainer: {
+        defaultProps: {
+          maxWidth: "lg"
+        }
       }
     }
-  }
-});
+  });
+}
 
-export default theme;
+export default createAppTheme("light");


### PR DESCRIPTION
## Summary
- add a color mode toggle in the app bar so users can switch between light and dark themes
- persist the selected color mode in local storage and create themes dynamically for each palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8e862f98832aac1d564392c7f973