### PR TITLE
feat: auto refresh results tab tasks

### DIFF
--- a/frontend_server/src/App.tsx
+++ b/frontend_server/src/App.tsx
@@ -237,6 +237,7 @@ export default function App() {
                 token={token}
                 user={user}
                 onNotify={showNotification}
+                active={activeTab === 2}
               />
             </TabPanel>
           </Stack>


### PR DESCRIPTION
## Summary
- refresh the task list automatically when the Results tab becomes active
- poll for updated tasks every 30 seconds while viewing Results without repeated toast spam

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddab01ae10832a957d021b8724964b