### PR TITLE
Limit result panel to final step summary

### DIFF
--- a/frontend_server/src/components/TaskManagementPanel.tsx
+++ b/frontend_server/src/components/TaskManagementPanel.tsx
@@ -340,7 +340,19 @@ export default function TaskManagementPanel({
       const message = result.error ?? `Request failed with ${result.status}`;
       onNotify({ message, severity: "error" });
     }
-    setResultContent(formatPayload(result.data));
+    const responseData = result.data;
+    const summaryEntries =
+      responseData && Array.isArray(responseData.summary)
+        ? (responseData.summary as unknown[])
+        : [];
+    const lastSummary =
+      summaryEntries.length > 0
+        ? summaryEntries[summaryEntries.length - 1]
+        : null;
+    const content = lastSummary
+      ? formatPayload(lastSummary)
+      : formatPayload(responseData);
+    setResultContent(content);
     const responseSteps =
       result.ok && Array.isArray(result.data?.steps)
         ? (result.data?.steps as StepInfo[])


### PR DESCRIPTION
## Summary
- update the task result loader to extract only the last summary entry for display
- fall back to rendering the full result payload when no summary steps exist

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deb234bb1c832aaf0f0e1c827c1c70