### PR TITLE
Add persistent log storage for backend services

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,10 +7,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # This is your "cd"
 WORKDIR /app
 
-# Location for persistent application data such as the SQLite database.
-RUN mkdir -p /data
+# Location for persistent application data such as the SQLite database and logs.
+RUN mkdir -p /data /logs
 ENV AITOOL_DB_PATH=/data/auth.db
-VOLUME ["/data"]
+VOLUME ["/data", "/logs"]
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/Dockerfile.queue
+++ b/Dockerfile.queue
@@ -6,10 +6,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Location for persistent application data such as the SQLite database.
-RUN mkdir -p /data
+# Location for persistent application data such as the SQLite database and logs.
+RUN mkdir -p /data /logs
 ENV AITOOL_DB_PATH=/data/auth.db
-VOLUME ["/data"]
+VOLUME ["/data", "/logs"]
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,10 @@ services:
     environment:
       REDIS_URL: redis://redis:6379/0
       BACKEND_LOG_LEVEL: ${BACKEND_LOG_LEVEL:-INFO}
+      BACKEND_LOG_FILE: /logs/backend.log
     volumes:
       - ~/app_db:/data
+      - backend-logs:/logs
     depends_on:
       - redis
 
@@ -24,8 +26,10 @@ services:
     environment:
       REDIS_URL: redis://redis:6379/0
       BACKEND_LOG_LEVEL: ${BACKEND_LOG_LEVEL:-INFO}
+      BACKEND_LOG_FILE: /logs/backend.log
     volumes:
       - ~/app_db:/data
+      - backend-logs:/logs
     depends_on:
       - redis
 
@@ -48,3 +52,4 @@ services:
 volumes:
   backend-data:
   redis-data:
+  backend-logs:


### PR DESCRIPTION
## Summary
- mount a shared backend-logs volume for the API and queue services
- configure both services to write logs to /logs/backend.log
- ensure Docker images create and expose the /logs directory for persistence

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0885c8b0832a871cff9d25f51356