### PR TITLE
Allow multi-target runs without platform and redesign task form

### DIFF
--- a/backend_server/queue_runner.py
+++ b/backend_server/queue_runner.py
@@ -61,7 +61,7 @@ def _process_task(redis_client: Any, raw_task: str) -> None:
             task["prompt"],
             task["tasks"],
             task["server"],
-            task["platform"],
+            task.get("platform"),
             reports_folder,
             task["debug"],
             task_id=task_id,

--- a/backend_server/runner.py
+++ b/backend_server/runner.py
@@ -576,7 +576,7 @@ def create_driver(_server, _platform="android",
 
 def _prepare_target_contexts(
     server: str,
-    platform: str,
+    platform: Optional[str],
     targets: Optional[List[Dict[str, Any]]],
 ) -> Tuple[Dict[str, TargetContext], str]:
     """Create drivers for all requested targets and return them."""
@@ -605,6 +605,10 @@ def _prepare_target_contexts(
             is_default = bool(cfg.get("default") or cfg.get("is_default"))
             configs.append((alias, str(target_server), str(target_platform), is_default))
     else:
+        if not platform:
+            raise ValueError(
+                "A platform must be provided when no targets are configured"
+            )
         alias = platform or "default"
         configs.append((alias, server, platform, True))
 
@@ -1378,7 +1382,7 @@ def _run_tasks(
     prompt: str,
     tasks: List[Dict[str, Any]],
     server: str,
-    platform: str,
+    platform: Optional[str],
     reports_folder: str,
     debug: bool = False,
     task_id: Optional[str] = None,
@@ -1689,7 +1693,7 @@ def run_tasks(
     prompt: str,
     tasks: List[Dict[str, Any]],
     server: str,
-    platform: str,
+    platform: Optional[str],
     reports_folder: str,
     debug: bool = False,
     task_id: Optional[str] = None,
@@ -1715,7 +1719,7 @@ async def run_tasks_async(
     prompt: str,
     tasks: List[Dict[str, Any]],
     server: str,
-    platform: str,
+    platform: Optional[str],
     reports_folder: str,
     debug: bool = False,
     task_id: Optional[str] = None,

--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -21,11 +21,29 @@ export interface AuthResponse {
   user: AuthenticatedUser;
 }
 
+export interface AutomationTaskDefinition {
+  name: string;
+  details: string;
+  scope?: string;
+  skip?: boolean;
+  target?: string;
+  apps?: string[];
+  [extra: string]: unknown;
+}
+
+export interface TargetConfiguration {
+  name: string;
+  platform: string;
+  server?: string;
+  default?: boolean;
+}
+
 export interface RunTaskPayload {
   prompt: string;
-  tasks: unknown[];
+  tasks: AutomationTaskDefinition[];
   server: string;
-  platform: string;
+  platform?: string;
+  targets?: TargetConfiguration[];
   reports_folder: string;
   debug: boolean;
   repeat: number;


### PR DESCRIPTION
## Summary
- allow run requests to omit the top-level platform when automation targets are supplied and validate this on the API
- update the runner and queue worker to work with optional platforms while enforcing platform presence when no targets exist
- rebuild the Run Task UI to collect task details and optional target definitions through structured form controls instead of raw JSON

## Testing
- npm run build
- python -m compileall backend_server *(fails: existing invalid import path in legacy CLI modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e0228501c0832a80a9dd5a4f670361