### PR TITLE
Allow runs with targets to omit global server

### DIFF
--- a/backend_server/README.md
+++ b/backend_server/README.md
@@ -63,6 +63,10 @@ curl -X POST "http://<server-ip>:8090/run" \
 The response returns the aggregated summary along with the path to the generated
 `summary.json` report inside the reports directory.
 
+When you define one or more automation targets the runner no longer requires the
+top-level `server` and `platform` fields — each target provides its own
+configuration instead.
+
 ### Coordinating multi-platform flows
 
 When a scenario requires two or more platforms to work together—such as approving

--- a/backend_server/queue_runner.py
+++ b/backend_server/queue_runner.py
@@ -60,7 +60,7 @@ def _process_task(redis_client: Any, raw_task: str) -> None:
         result = _run_tasks(
             task["prompt"],
             task["tasks"],
-            task["server"],
+            task.get("server"),
             task.get("platform"),
             reports_folder,
             task["debug"],

--- a/backend_server/runner.py
+++ b/backend_server/runner.py
@@ -575,13 +575,14 @@ def create_driver(_server, _platform="android",
 
 
 def _prepare_target_contexts(
-    server: str,
+    server: Optional[str],
     platform: Optional[str],
     targets: Optional[List[Dict[str, Any]]],
 ) -> Tuple[Dict[str, TargetContext], str]:
     """Create drivers for all requested targets and return them."""
 
     configs: List[Tuple[str, str, str, bool]] = []
+    base_server = (server or "").strip()
 
     if targets:
         for index, raw_cfg in enumerate(targets):
@@ -593,7 +594,8 @@ def _prepare_target_contexts(
                 or f"target{index + 1}"
             )
             target_platform = cfg.get("platform") or platform
-            target_server = cfg.get("server") or server
+            raw_target_server = cfg.get("server")
+            target_server = (raw_target_server or base_server or "").strip()
             if not target_platform:
                 raise ValueError(
                     f"Target '{alias}' is missing a platform configuration"
@@ -609,8 +611,12 @@ def _prepare_target_contexts(
             raise ValueError(
                 "A platform must be provided when no targets are configured"
             )
+        if not base_server:
+            raise ValueError(
+                "An automation server must be provided when no targets are configured"
+            )
         alias = platform or "default"
-        configs.append((alias, server, platform, True))
+        configs.append((alias, base_server, platform, True))
 
     contexts: Dict[str, TargetContext] = {}
     default_alias: Optional[str] = None
@@ -1381,7 +1387,7 @@ def generate_summary_report(reports_folder: str, summary: List[dict]) -> str:
 def _run_tasks(
     prompt: str,
     tasks: List[Dict[str, Any]],
-    server: str,
+    server: Optional[str],
     platform: Optional[str],
     reports_folder: str,
     debug: bool = False,
@@ -1692,7 +1698,7 @@ def _run_tasks(
 def run_tasks(
     prompt: str,
     tasks: List[Dict[str, Any]],
-    server: str,
+    server: Optional[str],
     platform: Optional[str],
     reports_folder: str,
     debug: bool = False,
@@ -1718,7 +1724,7 @@ def run_tasks(
 async def run_tasks_async(
     prompt: str,
     tasks: List[Dict[str, Any]],
-    server: str,
+    server: Optional[str],
     platform: Optional[str],
     reports_folder: str,
     debug: bool = False,

--- a/frontend_server/src/components/RunTaskForm.tsx
+++ b/frontend_server/src/components/RunTaskForm.tsx
@@ -333,9 +333,14 @@ export default function RunTaskForm({
           platform: target.platform
         };
         const serverUrl = target.server.trim();
-        if (serverUrl) {
-          targetConfig.server = serverUrl;
+        if (!serverUrl) {
+          onNotify({
+            message: `Provide an automation server for target "${name}"`,
+            severity: "warning"
+          });
+          return;
         }
+        targetConfig.server = serverUrl;
         if (target.default) {
           targetConfig.default = true;
         }
@@ -343,10 +348,11 @@ export default function RunTaskForm({
       }
     }
 
+    const trimmedServer = server.trim();
+
     const payload: RunTaskPayload = {
       prompt: promptValue,
       tasks: preparedTasks,
-      server,
       reports_folder: reportsFolder,
       debug,
       repeat: repeatCount,
@@ -354,6 +360,14 @@ export default function RunTaskForm({
     };
 
     if (targetForms.length === 0) {
+      if (!trimmedServer) {
+        onNotify({
+          message: "Provide an automation server when no targets are defined",
+          severity: "warning"
+        });
+        return;
+      }
+      payload.server = trimmedServer;
       payload.platform = platform;
     }
 
@@ -600,7 +614,7 @@ export default function RunTaskForm({
                     handleTargetChange(target.id, { server: event.target.value })
                   }
                   fullWidth
-                  helperText="Override the default server or leave as-is to use the suggested endpoint."
+                  helperText="Each target requires its own automation server endpoint."
                 />
                 <FormControlLabel
                   control={
@@ -654,6 +668,12 @@ export default function RunTaskForm({
         value={server}
         onChange={(event) => setServer(event.target.value)}
         fullWidth
+        disabled={targetForms.length > 0}
+        helperText={
+          targetForms.length > 0
+            ? "Automation targets specify their own server endpoints."
+            : "Used when no automation targets are configured."
+        }
       />
       <TextField
         select

--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -41,7 +41,7 @@ export interface TargetConfiguration {
 export interface RunTaskPayload {
   prompt: string;
   tasks: AutomationTaskDefinition[];
-  server: string;
+  server?: string;
   platform?: string;
   targets?: TargetConfiguration[];
   reports_folder: string;


### PR DESCRIPTION
## Summary
- let backend run requests omit the global server/platform when automation targets are provided, trimming blank values and validating inputs
- update driver creation to treat the server as optional, fall back per target, and make the queue worker resilient to missing values
- adjust the frontend run form and task editor to skip sending the global server/platform when targets exist, require per-target servers, and refresh the helper text and docs accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e02e045050832abea8af73334a98bc