### PR TITLE
Revamp home dashboard with health monitoring

### DIFF
--- a/frontend_server/src/App.tsx
+++ b/frontend_server/src/App.tsx
@@ -1,27 +1,31 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { ReactNode, SyntheticEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MouseEvent, ReactNode, SyntheticEvent } from "react";
 import {
   Alert,
   AppBar,
+  Avatar,
   Box,
   Button,
-  Chip,
   Container,
   CssBaseline,
   Grid,
+  Menu,
+  MenuItem,
   Snackbar,
   SnackbarCloseReason,
   Stack,
   Tab,
   Tabs,
   Toolbar,
+  Tooltip,
   Typography
 } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 
-import { API_BASE_DEFAULT } from "./api";
+import { API_BASE_DEFAULT, apiRequest } from "./api";
 import AuthPanel from "./components/AuthPanel";
 import ApiConfigPanel from "./components/ApiConfigPanel";
+import HomeInstructions from "./components/HomeInstructions";
 import RunTaskForm from "./components/RunTaskForm";
 import TaskManagementPanel from "./components/TaskManagementPanel";
 import theme from "./theme";
@@ -29,6 +33,8 @@ import type {
   AuthenticatedUser,
   NotificationState
 } from "./types";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import LogoutIcon from "@mui/icons-material/Logout";
 
 interface TabPanelProps {
   value: number;
@@ -68,7 +74,59 @@ export default function App() {
   const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<AuthenticatedUser | null>(null);
   const [authMode, setAuthMode] = useState<"login" | "signup">("login");
+  const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(null);
+  const [healthStatus, setHealthStatus] = useState<string>("Checking...");
+  const [healthOk, setHealthOk] = useState<boolean | null>(null);
+  const [healthLoading, setHealthLoading] = useState(false);
   const authPanelRef = useRef<HTMLDivElement | null>(null);
+  const lastHealthState = useRef<"success" | "error" | null>(null);
+  const isMountedRef = useRef(true);
+  const userName = useMemo(() => {
+    if (!user) {
+      return "";
+    }
+    const [namePart] = user.email.split("@");
+    return namePart
+      .split(/[._-]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }, [user]);
+  const userMenuOpen = Boolean(userMenuAnchor);
+  const userDomain = useMemo(() => {
+    if (!user) {
+      return "";
+    }
+    const [, domain = ""] = user.email.split("@");
+    return domain;
+  }, [user]);
+  const userInitials = useMemo(() => {
+    if (!user) {
+      return "";
+    }
+    if (userName) {
+      const letters = userName
+        .split(" ")
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase());
+      if (letters.length >= 2) {
+        return `${letters[0]}${letters[1]}`;
+      }
+      if (letters.length === 1) {
+        return letters[0];
+      }
+    }
+    return user.email.charAt(0).toUpperCase();
+  }, [user, userName]);
+  const displayEmail = useMemo(() => {
+    if (!user) {
+      return "";
+    }
+    if (!userDomain) {
+      return user.email;
+    }
+    return `${userName || user.email.split("@")[0]}@${userDomain}`;
+  }, [user, userDomain, userName]);
 
   const showNotification = useCallback((update: NotificationState) => {
     setNotification(update);
@@ -93,6 +151,12 @@ export default function App() {
       console.warn("Failed to parse stored authentication", error);
       localStorage.removeItem(AUTH_STORAGE_KEY);
     }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   const handleAuthNavigation = useCallback((mode: "login" | "signup") => {
@@ -122,8 +186,91 @@ export default function App() {
   const handleLogout = useCallback(() => {
     setToken(null);
     setUser(null);
+    setUserMenuAnchor(null);
     localStorage.removeItem(AUTH_STORAGE_KEY);
   }, []);
+
+  const performHealthCheck = useCallback(
+    async (silent = false) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+      setHealthStatus("Checking...");
+      setHealthOk(null);
+      setHealthLoading(true);
+      try {
+        const result = await apiRequest<{ status?: string }>(baseUrl, "get", "/");
+        if (!isMountedRef.current) {
+          return;
+        }
+        if (result.ok) {
+          const status = result.data?.status ?? "healthy";
+          setHealthStatus(status);
+          setHealthOk(true);
+          if (!silent || lastHealthState.current === "error") {
+            showNotification({
+              message: `API healthy: ${status}`,
+              severity: "success"
+            });
+          }
+          lastHealthState.current = "success";
+        } else {
+          const message = result.error ?? `Status ${result.status}`;
+          setHealthStatus(message);
+          setHealthOk(false);
+          if (!silent || lastHealthState.current !== "error") {
+            showNotification({
+              message: `API health check failed: ${message}`,
+              severity: "error"
+            });
+          }
+          lastHealthState.current = "error";
+        }
+      } catch (error) {
+        if (!isMountedRef.current) {
+          return;
+        }
+        const message =
+          error instanceof Error ? error.message : String(error ?? "Unknown error");
+        setHealthStatus(message);
+        setHealthOk(false);
+        if (!silent || lastHealthState.current !== "error") {
+          showNotification({
+            message: `API health check failed: ${message}`,
+            severity: "error"
+          });
+        }
+        lastHealthState.current = "error";
+      } finally {
+        if (isMountedRef.current) {
+          setHealthLoading(false);
+        }
+      }
+    },
+    [baseUrl, showNotification]
+  );
+
+  const handleUserMenuOpen = useCallback((event: MouseEvent<HTMLElement>) => {
+    setUserMenuAnchor(event.currentTarget);
+  }, []);
+
+  const handleUserMenuClose = useCallback(() => {
+    setUserMenuAnchor(null);
+  }, []);
+
+  const handleManualHealthCheck = useCallback(() => {
+    void performHealthCheck(false);
+  }, [performHealthCheck]);
+
+  useEffect(() => {
+    void performHealthCheck(true);
+    const interval = window.setInterval(() => {
+      void performHealthCheck(true);
+    }, 30000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [performHealthCheck]);
 
   function handleSnackbarClose(
     _event?: Event | SyntheticEvent,
@@ -147,20 +294,80 @@ export default function App() {
               </Typography>
             </Box>
             <Box sx={{ flexGrow: 1 }} />
-            <Chip
-              label={
-                user
-                  ? `Signed in as ${user.email} (${user.role})`
-                  : "Not authenticated"
-              }
-              color={user ? "success" : "default"}
-              variant={user ? "filled" : "outlined"}
-              sx={{ mr: user ? 1.5 : 2 }}
-            />
+            <Tooltip title={`API health status: ${healthStatus}`}>
+              <span>
+                <Button
+                  variant="contained"
+                  color={healthOk === false ? "error" : "success"}
+                  onClick={handleManualHealthCheck}
+                  disabled={healthLoading}
+                  sx={{ textTransform: "none", minWidth: 160 }}
+                >
+                  {healthLoading
+                    ? "Checking..."
+                    : healthOk
+                    ? "API Healthy"
+                    : "API Unreachable"}
+                </Button>
+              </span>
+            </Tooltip>
             {user ? (
-              <Button color="inherit" onClick={handleLogout}>
-                Log Out
-              </Button>
+              <>
+                <Tooltip title={displayEmail}>
+                  <Button
+                    color="inherit"
+                    onClick={handleUserMenuOpen}
+                    startIcon={
+                      <Avatar
+                        sx={{
+                          bgcolor: "secondary.main",
+                          width: 32,
+                          height: 32
+                        }}
+                      >
+                        {userInitials}
+                      </Avatar>
+                    }
+                    sx={{ textTransform: "none" }}
+                  >
+                    {userName || user.email.split("@")[0]}
+                  </Button>
+                </Tooltip>
+                <Menu
+                  anchorEl={userMenuAnchor}
+                  open={userMenuOpen}
+                  onClose={handleUserMenuClose}
+                  anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                  transformOrigin={{ vertical: "top", horizontal: "right" }}
+                >
+                  <MenuItem disabled sx={{ gap: 1 }}>
+                    <AccountCircleIcon fontSize="small" />
+                    <Box>
+                      <Typography variant="body2" fontWeight={600}>
+                        {userName || user.email.split("@")[0]}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {displayEmail}
+                      </Typography>
+                    </Box>
+                  </MenuItem>
+                  <MenuItem disabled>
+                    <Typography variant="caption" color="text.secondary">
+                      Role: {user.role}
+                    </Typography>
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      handleUserMenuClose();
+                      handleLogout();
+                    }}
+                    sx={{ gap: 1 }}
+                  >
+                    <LogoutIcon fontSize="small" />
+                    <Typography variant="body2">Log Out</Typography>
+                  </MenuItem>
+                </Menu>
+              </>
             ) : (
               <Stack direction="row" spacing={1} alignItems="center">
                 <Button
@@ -195,17 +402,19 @@ export default function App() {
               variant="scrollable"
               scrollButtons="auto"
             >
-              <Tab label="Health" {...tabProps(0)} />
+              <Tab label="Home" {...tabProps(0)} />
               <Tab label="Run Tasks" disabled={!token} {...tabProps(1)} />
               <Tab label="Results" disabled={!token} {...tabProps(2)} />
             </Tabs>
             <TabPanel value={activeTab} index={0}>
               <Grid container spacing={3}>
+                <Grid item xs={12}>
+                  <HomeInstructions />
+                </Grid>
                 <Grid item xs={12} md={6}>
                   <ApiConfigPanel
                     baseUrl={baseUrl}
                     onBaseUrlChange={setBaseUrl}
-                    onNotify={showNotification}
                   />
                 </Grid>
                 <Grid item xs={12} md={6}>

--- a/frontend_server/src/components/ApiConfigPanel.tsx
+++ b/frontend_server/src/components/ApiConfigPanel.tsx
@@ -1,48 +1,15 @@
-import { useCallback, useState } from "react";
-import { Button, Stack, TextField, Typography } from "@mui/material";
+import { Stack, TextField, Typography } from "@mui/material";
 import HealthAndSafetyIcon from "@mui/icons-material/HealthAndSafety";
-import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import CheckCircleIcon from "@mui/icons-material/CheckCircleOutline";
-
-import { apiRequest } from "../api";
-import type { NotificationState } from "../types";
 
 interface ApiConfigPanelProps {
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
-  onNotify: (notification: NotificationState) => void;
 }
 
 export default function ApiConfigPanel({
   baseUrl,
-  onBaseUrlChange,
-  onNotify
+  onBaseUrlChange
 }: ApiConfigPanelProps) {
-  const [healthStatus, setHealthStatus] = useState<string>("unknown");
-  const [healthOk, setHealthOk] = useState<boolean | null>(null);
-  const [checking, setChecking] = useState(false);
-
-  const handleHealthCheck = useCallback(async () => {
-    setChecking(true);
-    const result = await apiRequest<{ status?: string }>(baseUrl, "get", "/");
-    setChecking(false);
-
-    if (result.ok) {
-      const status = result.data?.status ?? "healthy";
-      setHealthStatus(status);
-      setHealthOk(true);
-      onNotify({
-        message: `API healthy: ${status}`,
-        severity: "success"
-      });
-    } else {
-      const message = result.error ?? `Status ${result.status}`;
-      setHealthStatus(message);
-      setHealthOk(false);
-      onNotify({ message: `Health check failed: ${message}`, severity: "error" });
-    }
-  }, [baseUrl, onNotify]);
-
   return (
     <Stack spacing={2}>
       <Stack direction="row" spacing={1} alignItems="center">
@@ -51,32 +18,18 @@ export default function ApiConfigPanel({
           API Configuration
         </Typography>
       </Stack>
+      <Typography variant="body2" color="text.secondary">
+        Update the base URL to point at the backend API that powers task
+        execution and monitoring. The health indicator in the top navigation bar
+        will use this URL for automatic status checks.
+      </Typography>
       <TextField
         label="API Base URL"
         value={baseUrl}
         onChange={(event) => onBaseUrlChange(event.target.value)}
+        placeholder="https://your-backend.example.com"
         fullWidth
       />
-      <Stack direction="row" spacing={2} alignItems="center">
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleHealthCheck}
-          disabled={checking}
-        >
-          Check Health
-        </Button>
-        <Stack direction="row" spacing={1} alignItems="center">
-          {healthOk ? (
-            <CheckCircleIcon color="success" fontSize="small" />
-          ) : healthOk === false ? (
-            <WarningAmberIcon color="warning" fontSize="small" />
-          ) : null}
-          <Typography variant="body2" color="text.secondary">
-            Health status: {healthStatus}
-          </Typography>
-        </Stack>
-      </Stack>
     </Stack>
   );
 }

--- a/frontend_server/src/components/HomeInstructions.tsx
+++ b/frontend_server/src/components/HomeInstructions.tsx
@@ -1,0 +1,74 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardMedia,
+  Divider,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+
+export default function HomeInstructions() {
+  return (
+    <Card elevation={3}>
+      <CardHeader
+        title="Welcome to the Home dashboard"
+        subheader="Follow these steps to run and review automated QA tasks."
+      />
+      <CardMedia
+        component="img"
+        image="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMGQyYmN2eXZramxhMTZ5ajltZmpzYjU5amZid3I2YzJ2bmUzNWNnYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/hqU2KkjW5bE2v2Z7Q2/giphy.gif"
+        alt="Animated demonstration of productivity"
+        sx={{ maxHeight: 320, objectFit: "cover" }}
+      />
+      <Divider />
+      <CardContent>
+        <Typography variant="subtitle1" gutterBottom>
+          How to use the FTNT QA AI Test Portal
+        </Typography>
+        <List>
+          <ListItem>
+            <ListItemIcon>
+              <CheckCircleIcon color="success" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Set your API endpoint"
+              secondary="Use the API Configuration panel to point the portal at the backend environment you want to exercise."
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon>
+              <CheckCircleIcon color="success" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Authenticate"
+              secondary="Sign in or create an account so the system can track your runs and permissions."
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon>
+              <CheckCircleIcon color="success" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Launch automated tasks"
+              secondary="Use the Run Tasks tab to configure AI-driven scenarios, prompts, and environments."
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon>
+              <CheckCircleIcon color="success" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Monitor progress and results"
+              secondary="Track status in the Results tab, review summaries, and download generated reports."
+            />
+          </ListItem>
+        </List>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- rename the landing tab to "Home" and introduce a guided HomeInstructions card with a walkthrough gif
- surface automatic API health polling and manual refresh button in the top bar while simplifying the configuration panel
- move authentication controls to a user menu in the app bar that shows initials, email, and logout action

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e1edc0d814832aac6c68d84d3dea7d