### PR TITLE
Refine home layout and API health indicator

### DIFF
--- a/frontend_server/src/components/ApiConfigPanel.tsx
+++ b/frontend_server/src/components/ApiConfigPanel.tsx
@@ -4,20 +4,24 @@ import HealthAndSafetyIcon from "@mui/icons-material/HealthAndSafety";
 interface ApiConfigPanelProps {
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
+  showHeader?: boolean;
 }
 
 export default function ApiConfigPanel({
   baseUrl,
-  onBaseUrlChange
+  onBaseUrlChange,
+  showHeader = true
 }: ApiConfigPanelProps) {
   return (
     <Stack spacing={2}>
-      <Stack direction="row" spacing={1} alignItems="center">
-        <HealthAndSafetyIcon color="primary" />
-        <Typography variant="h5" component="h2">
-          API Configuration
-        </Typography>
-      </Stack>
+      {showHeader ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <HealthAndSafetyIcon color="primary" />
+          <Typography variant="h5" component="h2">
+            API Configuration
+          </Typography>
+        </Stack>
+      ) : null}
       <Typography variant="body2" color="text.secondary">
         Update the base URL to point at the backend API that powers task
         execution and monitoring. The health indicator in the top navigation bar

--- a/frontend_server/src/components/HomeInstructions.tsx
+++ b/frontend_server/src/components/HomeInstructions.tsx
@@ -36,17 +36,8 @@ export default function HomeInstructions() {
               <CheckCircleIcon color="success" />
             </ListItemIcon>
             <ListItemText
-              primary="Set your API endpoint"
-              secondary="Use the API Configuration panel to point the portal at the backend environment you want to exercise."
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemIcon>
-              <CheckCircleIcon color="success" />
-            </ListItemIcon>
-            <ListItemText
-              primary="Authenticate"
-              secondary="Sign in or create an account so the system can track your runs and permissions."
+              primary="Verify connectivity"
+              secondary="Use the green health indicator in the header to confirm connectivity and open the gear icon to adjust the API base URL if needed."
             />
           </ListItem>
           <ListItem>


### PR DESCRIPTION
## Summary
- replace the API health button with a circular status indicator and add header access to API configuration
- move authentication and API configuration into dialogs to simplify the home tab content
- update home instructions copy to reflect the new layout and configuration entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1f3f39f38832a879f457341892475