### PR TITLE
Integrate pytest code generation into task management panel

### DIFF
--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -89,3 +89,21 @@ export interface RunResponse {
   task_id: string;
   task_ids: string[];
 }
+
+export interface PytestCodegenRequest {
+  summary?: Record<string, unknown>;
+  summary_path?: string;
+  task_name?: string;
+  task_index?: number;
+  model?: string;
+  temperature?: number;
+  max_output_tokens?: number;
+}
+
+export interface PytestCodegenResponse {
+  code: string;
+  model: string;
+  task_name?: string | null;
+  task_index: number;
+  function_name?: string | null;
+}


### PR DESCRIPTION
## Summary
- add TypeScript models for the pytest code generation API
- capture task summary metadata in the task management panel and surface a scenario selector
- integrate the /codegen/pytest endpoint to generate and display pytest source from the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55b45c6b0832a97f16584124f17a3