### PR TITLE
Add UI to manage and rerun generated pytest modules

### DIFF
--- a/frontend_server/src/App.tsx
+++ b/frontend_server/src/App.tsx
@@ -32,6 +32,7 @@ import ApiConfigPanel from "./components/ApiConfigPanel";
 import HomeInstructions from "./components/HomeInstructions";
 import RunTaskForm from "./components/RunTaskForm";
 import TaskManagementPanel from "./components/TaskManagementPanel";
+import CodeLibraryPanel from "./components/CodeLibraryPanel";
 import theme from "./theme";
 import type {
   AuthenticatedUser,
@@ -471,6 +472,7 @@ export default function App() {
               <Tab label="Home" {...tabProps(0)} />
               <Tab label="Run Tasks" disabled={!token} {...tabProps(1)} />
               <Tab label="Results" disabled={!token} {...tabProps(2)} />
+              <Tab label="Code Library" disabled={!token} {...tabProps(3)} />
             </Tabs>
             <TabPanel value={activeTab} index={0}>
               <HomeInstructions />
@@ -489,6 +491,14 @@ export default function App() {
                 user={user}
                 onNotify={showNotification}
                 active={activeTab === 2}
+              />
+            </TabPanel>
+            <TabPanel value={activeTab} index={3}>
+              <CodeLibraryPanel
+                baseUrl={baseUrl}
+                token={token}
+                onNotify={showNotification}
+                active={activeTab === 3}
               />
             </TabPanel>
           </Stack>

--- a/frontend_server/src/components/CodeLibraryPanel.tsx
+++ b/frontend_server/src/components/CodeLibraryPanel.tsx
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  Tooltip,
+  Typography
+} from "@mui/material";
+
+import { apiRequest, formatPayload } from "../api";
+import type {
+  CodegenRecordDetail,
+  CodegenRecordSummary,
+  NotificationState,
+  PytestExecutionResponse
+} from "../types";
+import JsonOutput from "./JsonOutput";
+import PlayCircleIcon from "@mui/icons-material/PlayCircle";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface CodeLibraryPanelProps {
+  baseUrl: string;
+  token: string | null;
+  active: boolean;
+  onNotify: (update: NotificationState) => void;
+}
+
+export default function CodeLibraryPanel({
+  baseUrl,
+  token,
+  active,
+  onNotify
+}: CodeLibraryPanelProps) {
+  const [loading, setLoading] = useState(false);
+  const [entries, setEntries] = useState<CodegenRecordSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [selectedDetail, setSelectedDetail] = useState<CodegenRecordDetail | null>(
+    null
+  );
+  const [executionLoading, setExecutionLoading] = useState(false);
+  const [executionResult, setExecutionResult] =
+    useState<PytestExecutionResponse | null>(null);
+
+  const hasEntries = entries.length > 0;
+  const requireToken = useCallback(() => {
+    if (!token) {
+      onNotify({
+        message: "Authenticate to view stored code",
+        severity: "warning"
+      });
+      return null;
+    }
+    return token;
+  }, [token, onNotify]);
+
+  const loadHistory = useCallback(async () => {
+    const authToken = requireToken();
+    if (!authToken) {
+      return;
+    }
+    setLoading(true);
+    const response = await apiRequest<CodegenRecordSummary[]>(
+      baseUrl,
+      "get",
+      "/codegen/pytest",
+      undefined,
+      authToken
+    );
+    setLoading(false);
+    if (response.ok && response.data) {
+      setEntries(response.data);
+      if (
+        response.data.length === 0 ||
+        !response.data.some((entry) => entry.id === selectedId)
+      ) {
+        setSelectedId(null);
+        setSelectedDetail(null);
+        setExecutionResult(null);
+      }
+    } else {
+      const message = response.error ?? `Request failed with ${response.status}`;
+      onNotify({ message, severity: "error" });
+    }
+  }, [baseUrl, requireToken, onNotify, selectedId]);
+
+  useEffect(() => {
+    if (active) {
+      void loadHistory();
+    }
+  }, [active, loadHistory]);
+
+  const loadDetail = useCallback(
+    async (entryId: number) => {
+      const authToken = requireToken();
+      if (!authToken) {
+        return;
+      }
+      setDetailLoading(true);
+      const response = await apiRequest<CodegenRecordDetail>(
+        baseUrl,
+        "get",
+        `/codegen/pytest/${entryId}`,
+        undefined,
+        authToken
+      );
+      setDetailLoading(false);
+      if (response.ok && response.data) {
+        setSelectedDetail(response.data);
+        setExecutionResult(null);
+      } else {
+        const message = response.error ?? `Request failed with ${response.status}`;
+        onNotify({ message, severity: "error" });
+      }
+    },
+    [baseUrl, requireToken, onNotify]
+  );
+
+  const handleSelect = useCallback(
+    (entryId: number) => {
+      setSelectedId(entryId);
+      void loadDetail(entryId);
+    },
+    [loadDetail]
+  );
+
+  const handleExecute = useCallback(async () => {
+    if (!selectedId) {
+      return;
+    }
+    const authToken = requireToken();
+    if (!authToken) {
+      return;
+    }
+    setExecutionLoading(true);
+    setExecutionResult(null);
+    const response = await apiRequest<PytestExecutionResponse>(
+      baseUrl,
+      "post",
+      `/codegen/pytest/${selectedId}/execute`,
+      {},
+      authToken
+    );
+    setExecutionLoading(false);
+    if (response.ok && response.data) {
+      setExecutionResult(response.data);
+      const exit = response.data.exit_code;
+      const message = exit === 0
+        ? "Pytest module executed successfully"
+        : `Pytest module finished with exit code ${exit}`;
+      onNotify({ message, severity: exit === 0 ? "success" : "warning" });
+    } else {
+      const message = response.error ?? `Request failed with ${response.status}`;
+      onNotify({ message, severity: "error" });
+    }
+  }, [baseUrl, onNotify, requireToken, selectedId]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="h5" fontWeight={600}>
+          Generated Code Library
+        </Typography>
+        <Tooltip title="Refresh">
+          <span>
+            <Button
+              startIcon={<RefreshIcon />}
+              onClick={() => {
+                void loadHistory();
+              }}
+              disabled={loading}
+            >
+              Refresh
+            </Button>
+          </span>
+        </Tooltip>
+      </Stack>
+      {!hasEntries && !loading ? (
+        <Alert severity="info">
+          Generate pytest code from a task result to populate this library.
+        </Alert>
+      ) : null}
+      {loading ? (
+        <Stack direction="row" spacing={2} alignItems="center">
+          <CircularProgress size={24} />
+          <Typography variant="body2" color="text.secondary">
+            Loading stored code…
+          </Typography>
+        </Stack>
+      ) : null}
+      <Stack direction={{ xs: "column", md: "row" }} spacing={3}>
+        <Box flex={1}>
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Saved Entries
+              </Typography>
+              {entries.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  No code entries available.
+                </Typography>
+              ) : (
+                <List dense disablePadding>
+                  {entries.map((entry) => {
+                    const secondary = [
+                      entry.model ? `Model: ${entry.model}` : null,
+                      entry.updated_at ? `Updated: ${entry.updated_at}` : null
+                    ]
+                      .filter(Boolean)
+                      .join(" • ");
+                    return (
+                      <ListItem key={entry.id} disablePadding>
+                        <ListItemButton
+                          selected={entry.id === selectedId}
+                          onClick={() => handleSelect(entry.id)}
+                        >
+                          <ListItemText
+                            primary={entry.task_name ?? `Entry #${entry.id}`}
+                            secondary={secondary}
+                          />
+                        </ListItemButton>
+                      </ListItem>
+                    );
+                  })}
+                </List>
+              )}
+            </CardContent>
+          </Card>
+        </Box>
+        <Box flex={{ xs: 1, md: 2 }}>
+          <Card variant="outlined" sx={{ height: "100%" }}>
+            <CardContent sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Entry Details</Typography>
+                <Tooltip title={selectedId ? "Execute with pytest" : "Select an entry first"}>
+                  <span>
+                    <Button
+                      variant="contained"
+                      startIcon={<PlayCircleIcon />}
+                      disabled={!selectedId || executionLoading || detailLoading}
+                      onClick={() => {
+                        void handleExecute();
+                      }}
+                    >
+                      {executionLoading ? "Running…" : "Run Pytest"}
+                    </Button>
+                  </span>
+                </Tooltip>
+              </Stack>
+              {detailLoading ? (
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <CircularProgress size={20} />
+                  <Typography variant="body2" color="text.secondary">
+                    Loading entry details…
+                  </Typography>
+                </Stack>
+              ) : null}
+              {!selectedDetail && !detailLoading ? (
+                <Typography variant="body2" color="text.secondary">
+                  Select an entry to review the generated code and execute it.
+                </Typography>
+              ) : null}
+              {selectedDetail ? (
+                <Stack spacing={1}>
+                  <Typography variant="subtitle1" fontWeight={600}>
+                    {selectedDetail.task_name ?? `Entry #${selectedDetail.id}`}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Entry ID: {selectedDetail.id} • Scenario Index: {selectedDetail.task_index}
+                  </Typography>
+                  {selectedDetail.model ? (
+                    <Typography variant="body2" color="text.secondary">
+                      Model: {selectedDetail.model}
+                    </Typography>
+                  ) : null}
+                  {selectedDetail.function_name ? (
+                    <Typography variant="body2" color="text.secondary">
+                      Test Function: {selectedDetail.function_name}
+                    </Typography>
+                  ) : null}
+                  {selectedDetail.summary_path ? (
+                    <Typography variant="body2" color="text.secondary">
+                      Summary Path: {selectedDetail.summary_path}
+                    </Typography>
+                  ) : null}
+                  <Typography variant="body2" color="text.secondary">
+                    Created: {selectedDetail.created_at ?? "Unknown"}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Updated: {selectedDetail.updated_at ?? "Unknown"}
+                  </Typography>
+                  <Divider flexItem sx={{ my: 1 }} />
+                  <JsonOutput title="Generated Pytest Code" content={selectedDetail.code} minHeight={260} />
+                  <JsonOutput
+                    title="Summary Snapshot"
+                    content={formatPayload(selectedDetail.summary_json ?? null)}
+                    minHeight={200}
+                  />
+                </Stack>
+              ) : null}
+              {executionResult ? (
+                <Stack spacing={1}>
+                  <Divider flexItem sx={{ my: 1 }} />
+                  <Typography variant="subtitle1" fontWeight={600}>
+                    Execution Result
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Exit Code: {executionResult.exit_code} • Duration: {executionResult.duration_seconds.toFixed(2)}s
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Started: {executionResult.started_at}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Finished: {executionResult.finished_at}
+                  </Typography>
+                  <JsonOutput title="stdout" content={executionResult.stdout} minHeight={160} />
+                  <JsonOutput title="stderr" content={executionResult.stderr} minHeight={120} />
+                </Stack>
+              ) : null}
+            </CardContent>
+          </Card>
+        </Box>
+      </Stack>
+    </Stack>
+  );
+}

--- a/frontend_server/src/components/TaskManagementPanel.tsx
+++ b/frontend_server/src/components/TaskManagementPanel.tsx
@@ -467,7 +467,11 @@ export default function TaskManagementPanel({
 
     if (response.ok && response.data) {
       setCodegenResponse(response.data);
-      onNotify({ message: "Pytest code generated", severity: "success" });
+      const entryId = response.data.record_id;
+      const message = Number.isFinite(entryId)
+        ? `Pytest code generated (entry #${entryId})`
+        : "Pytest code generated";
+      onNotify({ message, severity: "success" });
     } else {
       const message = response.error ?? `Request failed with ${response.status}`;
       onNotify({ message, severity: "error" });
@@ -914,6 +918,11 @@ export default function TaskManagementPanel({
           </Stack>
           {codegenResponse ? (
             <Stack spacing={0.5}>
+              {Number.isFinite(codegenResponse.record_id) ? (
+                <Typography variant="body2" color="text.secondary">
+                  Entry ID: {codegenResponse.record_id}
+                </Typography>
+              ) : null}
               <Typography variant="body2" color="text.secondary">
                 Model: {codegenResponse.model}
               </Typography>

--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -101,9 +101,36 @@ export interface PytestCodegenRequest {
 }
 
 export interface PytestCodegenResponse {
+  record_id: number;
   code: string;
   model: string;
   task_name?: string | null;
   task_index: number;
   function_name?: string | null;
+}
+
+export interface CodegenRecordSummary {
+  id: number;
+  task_name?: string | null;
+  task_index: number;
+  model?: string | null;
+  function_name?: string | null;
+  summary_path?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface CodegenRecordDetail extends CodegenRecordSummary {
+  code: string;
+  summary_json?: Record<string, unknown> | null;
+}
+
+export interface PytestExecutionResponse {
+  record_id: number;
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+  started_at: string;
+  finished_at: string;
+  duration_seconds: number;
 }


### PR DESCRIPTION
## Summary
- persist generated pytest code in a new `codegen_history` table and expose list/detail/execute API endpoints
- return the saved entry id from the codegen endpoint and surface it in the existing results panel
- add a Code Library tab that lists stored modules, shows details, and allows executing the saved pytest code

## Testing
- npm run build
- python -m compileall backend_server

------
https://chatgpt.com/codex/tasks/task_e_68e5718ba298832ab3dc9334d10b97e2