### PR TITLE
Populate generated tests with recorded driver config

### DIFF
--- a/backend_server/libraries/codegen.py
+++ b/backend_server/libraries/codegen.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import os
 import re
+import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 from dotenv import load_dotenv
 from openai import OpenAI
@@ -35,6 +37,29 @@ class CodegenResult:
 _CODE_FENCE_PATTERN = re.compile(r"```(?:python)?\s*([\s\S]+?)\s*```", re.IGNORECASE)
 
 
+_DEFAULT_CAPABILITIES: Dict[str, Dict[str, Any]] = {
+    "android": {
+        "platformName": "Android",
+        "automationName": "uiautomator2",
+        "deviceName": "google_api",
+        "language": "en",
+        "locale": "US",
+        "appium:newCommandTimeout": 0,
+        "appium:uiautomator2ServerLaunchTimeout": 0,
+        "appium:noReset": True,
+    },
+    "ios": {
+        "appium:xcodeSigningId": "App Development",
+        "appium:automationName": "XCUITest",
+        "platformName": "iOS",
+        "appium:deviceName": "iPhone8-ios16",
+        "appium:udid": "f67d7ce40691d9ab546d7362a4cc7a6182870de2",
+        "appium:bundleId": "FortiToken-Mobile",
+        "appium:wdaLocalPort": "8101",
+    },
+}
+
+
 def _strip_code_fences(content: str) -> str:
     """Return ``content`` without Markdown code fences when present."""
 
@@ -51,6 +76,265 @@ def _slugify(value: str, fallback: str = "scenario") -> str:
         return fallback
     slug = re.sub(r"[^0-9a-zA-Z]+", "_", value.strip().lower()).strip("_")
     return slug or fallback
+
+
+def _safe_trimmed_str(value: Any) -> Optional[str]:
+    """Return ``value`` stripped when it is a non-empty string."""
+
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            return trimmed
+    return None
+
+
+def _load_run_request_payload(run_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Fetch the stored run request payload for ``run_id`` when available."""
+
+    if not run_id:
+        return None
+
+    try:
+        from backend_server import task_store  # lazy import to avoid circular deps
+    except Exception:  # pragma: no cover - import guard
+        return None
+
+    try:
+        conn = task_store._connect()
+    except Exception:  # pragma: no cover - database unavailable
+        logger.debug("Failed to open task store connection", exc_info=True)
+        return None
+
+    try:
+        task_store.ensure_task_tables(conn)
+        cursor = conn.execute(
+            "SELECT request_json FROM task_runs WHERE id = ?",
+            (run_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        raw_value = row["request_json"] if isinstance(row, sqlite3.Row) else row[0]
+        if not raw_value:
+            return None
+        return json.loads(raw_value)
+    except Exception:  # pragma: no cover - defensive guard
+        logger.debug("Failed to load request payload for run %s", run_id, exc_info=True)
+        return None
+    finally:
+        conn.close()
+
+
+def _collect_targets_from_payload(payload: Any) -> list[Dict[str, Any]]:
+    """Return a list of target configuration dictionaries."""
+
+    if not isinstance(payload, dict):
+        return []
+
+    targets = payload.get("targets")
+    if not isinstance(targets, Iterable):
+        return []
+
+    result: list[Dict[str, Any]] = []
+    for item in targets:
+        if isinstance(item, dict):
+            result.append(dict(item))
+    return result
+
+
+def _collect_step_context(task_entry: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+    """Return the first target alias and platform seen within the task steps."""
+
+    target_alias: Optional[str] = None
+    platform: Optional[str] = None
+    steps = task_entry.get("steps")
+    if isinstance(steps, Iterable):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            if target_alias is None:
+                alias = _safe_trimmed_str(
+                    step.get("target")
+                    or step.get("device")
+                    or step.get("session")
+                )
+                if alias:
+                    target_alias = alias
+            if platform is None:
+                platform_hint = _safe_trimmed_str(
+                    step.get("platform")
+                    or step.get("platformName")
+                    or step.get("platform_name")
+                )
+                if platform_hint:
+                    platform = platform_hint.lower()
+            if target_alias and platform:
+                break
+    return target_alias, platform
+
+
+def _extract_driver_context(
+    summary_payload: Any,
+    metadata: Dict[str, Any],
+    task_entry: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Derive driver configuration details for ``task_entry``."""
+
+    run_request = metadata.get("run_request")
+    if not isinstance(run_request, dict):
+        run_request = _load_run_request_payload(task_entry.get("task_id"))
+        if run_request:
+            metadata["run_request"] = run_request
+
+    targets: list[Dict[str, Any]] = []
+    for source in (metadata, run_request, summary_payload):
+        targets.extend(_collect_targets_from_payload(source))
+
+    selected_alias, platform = _collect_step_context(task_entry)
+
+    selected_target: Optional[Dict[str, Any]] = None
+    if targets:
+        lookup = {
+            _safe_trimmed_str(
+                item.get("name")
+                or item.get("alias")
+                or item.get("id")
+            ).lower(): item
+            for item in targets
+            if _safe_trimmed_str(
+                item.get("name")
+                or item.get("alias")
+                or item.get("id")
+            )
+        }
+        if selected_alias and selected_alias.lower() in lookup:
+            selected_target = dict(lookup[selected_alias.lower()])
+        else:
+            default_target = next(
+                (
+                    dict(item)
+                    for item in targets
+                    if isinstance(item, dict) and item.get("default")
+                ),
+                None,
+            )
+            selected_target = default_target or dict(targets[0])
+
+    if platform is None:
+        platform_source = (
+            selected_target.get("platform")
+            if isinstance(selected_target, dict)
+            else None
+        ) or metadata.get("platform")
+        if not platform_source and isinstance(run_request, dict):
+            platform_source = run_request.get("platform")
+        platform_candidate = _safe_trimmed_str(platform_source)
+        platform = platform_candidate.lower() if platform_candidate else None
+
+    server_url: Optional[str] = None
+    server_source = None
+    if isinstance(selected_target, dict):
+        server_candidate = _safe_trimmed_str(selected_target.get("server"))
+        if server_candidate:
+            server_url = server_candidate
+            server_source = "target"
+
+    if server_url is None and isinstance(run_request, dict):
+        server_candidate = _safe_trimmed_str(run_request.get("server"))
+        if server_candidate:
+            server_url = server_candidate
+            server_source = "request"
+
+    if server_url is None:
+        server_candidate = _safe_trimmed_str(metadata.get("server"))
+        if server_candidate:
+            server_url = server_candidate
+            server_source = "metadata"
+
+    capabilities: Optional[Dict[str, Any]] = None
+    if isinstance(selected_target, dict):
+        for key in ("capabilities", "desired_capabilities", "options"):
+            value = selected_target.get(key)
+            if isinstance(value, dict):
+                capabilities = dict(value)
+                break
+
+    if capabilities is None and isinstance(run_request, dict):
+        for key in ("capabilities", "desired_capabilities"):
+            value = run_request.get(key)
+            if isinstance(value, dict):
+                capabilities = dict(value)
+                break
+
+    if capabilities is None and platform in _DEFAULT_CAPABILITIES:
+        capabilities = copy.deepcopy(_DEFAULT_CAPABILITIES[platform])
+
+    if not any((server_url, platform, capabilities, selected_alias)):
+        return None
+
+    context: Dict[str, Any] = {}
+    if selected_alias:
+        context["target_alias"] = selected_alias
+    if platform:
+        context["platform"] = platform
+    if server_url:
+        context["server_url"] = server_url
+    if server_source:
+        context["server_source"] = server_source
+    if capabilities:
+        context["capabilities"] = capabilities
+
+    return context or None
+
+
+def _suggest_fixture_name(driver_context: Optional[Dict[str, Any]]) -> str:
+    """Return a descriptive fixture name based on ``driver_context``."""
+
+    platform = (driver_context or {}).get("platform")
+    if platform == "android":
+        return "android_driver"
+    if platform == "web":
+        return "web_driver"
+    return "ios_driver"
+
+
+def _driver_instruction(
+    driver_context: Optional[Dict[str, Any]],
+    fixture_name: str,
+) -> str:
+    """Return instruction text for configuring the driver fixture."""
+
+    if not driver_context:
+        return (
+            f"4. Create a pytest fixture named '{fixture_name}' that builds an Appium "
+            "driver using an Appium server URL sourced from the APPIUM_SERVER_URL "
+            "environment variable (default to http://localhost:4723) and placeholder "
+            "desired capabilities with TODO comments for values that must be customised.\n"
+        )
+
+    server_url = driver_context.get("server_url") or "http://localhost:4723"
+    platform = driver_context.get("platform")
+    alias = driver_context.get("target_alias")
+    capabilities = driver_context.get("capabilities")
+
+    details: list[str] = []
+    details.append(
+        f"4. Create a pytest fixture named '{fixture_name}' that builds an Appium driver "
+        f"using the recorded server '{server_url}'."
+    )
+    if platform:
+        details.append(f"   - Platform: {platform}")
+    if alias:
+        details.append(f"   - Target alias used during the run: {alias}")
+    if capabilities:
+        capabilities_json = json.dumps(capabilities, indent=2, ensure_ascii=False)
+        details.append("   - Desired capabilities (use exactly as captured):")
+        details.append(capabilities_json)
+    else:
+        details.append(
+            "   - Provide concrete desired capabilities appropriate for this platform."
+        )
+    return "\n".join(details) + "\n"
 
 
 def _load_summary_from_path(summary_path: str) -> Dict[str, Any]:
@@ -73,9 +357,18 @@ def _load_summary_from_path(summary_path: str) -> Dict[str, Any]:
 
     try:
         with candidate.open("r", encoding="utf-8") as handle:
-            return json.load(handle)
+            data = json.load(handle)
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
         raise CodegenError(f"Summary file '{candidate}' is not valid JSON: {exc}") from exc
+
+    payload: Dict[str, Any]
+    if isinstance(data, dict):
+        payload = dict(data)
+    else:
+        payload = {"summary": data}
+
+    payload.setdefault("summary_path", str(candidate))
+    return payload
 
 
 def _select_summary_task(
@@ -120,11 +413,15 @@ def _build_messages(
     *,
     metadata: Dict[str, Any],
     function_name: str,
+    fixture_name: str,
 ) -> list[dict[str, Any]]:
     """Create the chat completion messages for the codegen request."""
 
     task_json = json.dumps(task_entry, indent=2, ensure_ascii=False)
     metadata_json = json.dumps(metadata, indent=2, ensure_ascii=False)
+    driver_instruction = _driver_instruction(
+        metadata.get("driver_context"), fixture_name
+    )
 
     system_prompt = (
         "You are a senior QA automation engineer specialising in pytest and Appium. "
@@ -142,13 +439,11 @@ def _build_messages(
         "2. Target the Appium Python client for iOS automation.\n"
         "3. Provide all necessary imports, including pytest, typing hints, "
         "AppiumBy, WebDriverWait, expected_conditions, and Optional.\n"
-        "4. Create a pytest fixture named 'ios_driver' that builds an Appium "
-        "driver using an Appium server URL sourced from the APPIUM_SERVER_URL "
-        "environment variable (default to http://localhost:4723) and placeholder "
-        "desired capabilities with TODO comments for values that must be customised.\n"
+        f"{driver_instruction}"
         "5. Implement helper functions as needed to keep the test readable, such as "
         "`tap` or `enter_text` using WebDriverWait for element lookup.\n"
-        "6. Define a test function named '{function_name}' that invokes the fixture.\n"
+        f"6. Define a test function named '{function_name}' that invokes the "
+        f"'{fixture_name}' fixture.\n"
         "7. Translate each step in the run summary into clear test logic with "
         "explanatory comments derived from the step explanations.\n"
         "8. Convert 'tap' actions into `.click()` calls, 'input' actions into "
@@ -204,7 +499,17 @@ def generate_pytest_from_summary(
         summary_payload.get("summary_path") if isinstance(summary_payload, dict) else None
     )
 
-    messages = _build_messages(task_entry, metadata=metadata, function_name=function_name)
+    driver_context = _extract_driver_context(summary_payload, metadata, task_entry)
+    if driver_context:
+        metadata["driver_context"] = driver_context
+
+    fixture_name = _suggest_fixture_name(driver_context)
+    messages = _build_messages(
+        task_entry,
+        metadata=metadata,
+        function_name=function_name,
+        fixture_name=fixture_name,
+    )
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:


### PR DESCRIPTION
## Summary
- load stored run request metadata to recover driver configuration
- include server and capability details in codegen prompts and fixture naming
- default to recorded Appium capabilities so generated tests are runnable without manual edits

## Testing
- python -m compileall backend_server/libraries/codegen.py

------
https://chatgpt.com/codex/tasks/task_e_68e57a61a2bc832a9c7d48cbae4e8a13