### PR TITLE
Add deletion endpoint and execution counters for code library

### DIFF
--- a/frontend_server/src/types.ts
+++ b/frontend_server/src/types.ts
@@ -118,6 +118,8 @@ export interface CodegenRecordSummary {
   summary_path?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  success_count?: number | null;
+  failure_count?: number | null;
 }
 
 export interface CodegenRecordDetail extends CodegenRecordSummary {


### PR DESCRIPTION
## Summary
- add persistent success and failure counters for generated code history and update them after pytest runs
- expose an authenticated API endpoint to delete stored generated code entries
- surface execution totals and a delete control in the code library UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5e4a82730832ab8b96a4f48938f93